### PR TITLE
feat(analysis): accountants may bill reports

### DIFF
--- a/app/analysis/edit/controller.js
+++ b/app/analysis/edit/controller.js
@@ -65,6 +65,7 @@ export default Controller.extend(AnalysisEditQueryParams.Mixin, {
 
   analysisIndexController: controller("analysis.index"),
   intersectionModel: reads("intersection.lastSuccessful.value.model"),
+  isAccountant: reads("session.data.user.isAccountant"),
 
   setup() {
     this.get("intersection").perform();
@@ -76,7 +77,7 @@ export default Controller.extend(AnalysisEditQueryParams.Mixin, {
       data: {
         ...prepareParams(this.get("allQueryParams")),
         editable: 1,
-        include: "task,project,customer"
+        include: "task,project,customer,user"
       }
     });
 
@@ -101,6 +102,10 @@ export default Controller.extend(AnalysisEditQueryParams.Mixin, {
   _task: computed("intersectionModel.task.id", function() {
     const id = this.get("intersectionModel.task.id");
     return id && this.store.peekRecord("task", id);
+  }),
+
+  hasSelectedOwnReports: computed("intersectionModel.user.id", function() {
+    return this.get("intersectionModel.user.id") === this.session.data.user.id;
   }),
 
   canVerify: computed(

--- a/app/analysis/edit/template.hbs
+++ b/app/analysis/edit/template.hbs
@@ -31,6 +31,7 @@
                     project=_project
                     task=_task
                   }}
+                  @disabled={{and this.isAccountant (not this.hasSelectedOwnReports)}}
                   as |t|
                 >
                   <f.input @name='task' as |fi|>
@@ -92,6 +93,7 @@
                       class="form-control"
                       onchange={{action fi.update value='target.value'}}
                       value={{fi.value}}
+                      disabled={{and this.isAccountant (not this.hasSelectedOwnReports)}}
                     >
                   </f.input>
 
@@ -103,6 +105,7 @@
                     <SyCheckbox
                       @checked={{fi.value}}
                       @on-change={{fi.update}}
+                      @disabled={{and this.isAccountant (not this.hasSelectedOwnReports)}}
                     >
                       Not billable
                       {{#if (eq model.notBillable null)}}
@@ -122,6 +125,7 @@
                     <SyCheckbox
                       @checked={{fi.value}}
                       @on-change={{fi.update}}
+                      @disabled={{and this.isAccountant (not this.hasSelectedOwnReports)}}
                     >
                       Needs Review
                       {{#if (eq model.review null)}}
@@ -141,7 +145,7 @@
                     <SyCheckbox
                       @checked={{fi.value}}
                       @on-change={{fi.update}}
-                      @title="You do not have appropriate roles for this action."
+                      @title={{not canBill "You do not have appropriate roles for this action."}}
                       @disabled={{not canBill}}
                     >
                       Billed

--- a/app/analysis/index/controller.js
+++ b/app/analysis/index/controller.js
@@ -197,6 +197,12 @@ const AnalysisController = Controller.extend(AnalysisQueryParams.Mixin, {
     return `The export limit is ${this.exportLimit}. Please use filters to reduce the amount of reports.`;
   }),
 
+  canBill: computed("session.data.user", function() {
+    return (
+      this.session.data.user.isAccountant || this.session.data.user.isSuperuser
+    );
+  }),
+
   exportLinks: config.APP.REPORTEXPORTS,
 
   exportLimit: config.APP.EXPORT_LIMIT,
@@ -458,7 +464,7 @@ const AnalysisController = Controller.extend(AnalysisQueryParams.Mixin, {
     },
 
     selectRow(report) {
-      if (this.get("can").can("edit report", report)) {
+      if (this.can.can("edit report", report) || this.canBill) {
         const selected = this.get("selectedReportIds");
 
         if (selected.includes(report.id)) {

--- a/app/analysis/index/template.hbs
+++ b/app/analysis/index/template.hbs
@@ -282,7 +282,7 @@
                   </colgroup>
                   <tbody>
                     {{#each reports as |report|}}
-                      <tr class="{{if (contains report.id this.selectedReportIds) 'selected'}} {{if (can 'edit report' report) 'pointer'}}" {{action 'selectRow' report}}>
+                      <tr class="{{if (contains report.id this.selectedReportIds) 'selected'}} {{if (or this.canBill (can 'edit report' report)) 'pointer'}}" {{action 'selectRow' report}}>
                         <td>{{report.user.username}}</td>
                         <td>{{moment-format report.date 'DD.MM.YYYY'}}</td>
                         <td>{{format-duration report.duration false}}</td>

--- a/app/models/report-intersection.js
+++ b/app/models/report-intersection.js
@@ -11,5 +11,6 @@ export default Model.extend({
 
   customer: belongsTo("customer"),
   project: belongsTo("project"),
-  task: belongsTo("task")
+  task: belongsTo("task"),
+  user: belongsTo("user")
 });

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -76,7 +76,7 @@ export default Model.extend({
   /**
    * Whether the user is an accountant
    */
-  isAccountant: attr("boolean"),
+  isAccountant: attr("boolean", { defaultValue: false }),
 
   /**
    * Whether the user completed the app tour

--- a/mirage/factories/user.js
+++ b/mirage/factories/user.js
@@ -15,6 +15,7 @@ export default Factory.extend({
   isStaff: true,
   isActive: true,
   isSuperuser: false,
+  isAccountant: false,
   tourDone: true,
 
   afterCreate(user, server) {

--- a/tests/acceptance/analysis-test.js
+++ b/tests/acceptance/analysis-test.js
@@ -219,4 +219,45 @@ module("Acceptance | analysis", function(hooks) {
     assert.notOk(find("tbody > tr:last-child.selected"));
     assert.dom("[data-test-edit-selected]").doesNotExist();
   });
+
+  test("can edit selected reports of other users as accountant", async function(assert) {
+    const user = this.server.create("user", { isAccountant: true });
+    this.server.get("users/me", function() {
+      return user;
+    });
+
+    this.server.create("report-intersection", {
+      userId: this.user.id
+    });
+
+    await visit("/analysis");
+
+    await selectChoose(
+      "[data-test-filter-customer]",
+      ".ember-power-select-option",
+      0
+    );
+
+    await click("tbody > tr:nth-child(1)");
+    await click("tbody > tr:nth-child(2)");
+    await click("[data-test-edit-selected]");
+
+    assert.ok(currentURL().includes("id=1%2C2"));
+
+    assert
+      .dom("[data-test-customer] div > div")
+      .hasAttribute("aria-disabled", "true");
+    assert
+      .dom("[data-test-project] div > div")
+      .hasAttribute("aria-disabled", "true");
+    assert
+      .dom("[data-test-task] div > div")
+      .hasAttribute("aria-disabled", "true");
+
+    assert.dom("[data-test-comment] input").isDisabled();
+    assert.dom("[data-test-not-billable] div > input").isDisabled();
+    assert.dom("[data-test-review] div > input").isDisabled();
+    assert.dom("[data-test-billed] div > input").isNotDisabled();
+    assert.dom("[data-test-verified] div > input").isDisabled();
+  });
 });

--- a/tests/unit/abilities/report-test.js
+++ b/tests/unit/abilities/report-test.js
@@ -11,6 +11,21 @@ module("Unit | Ability | report", function(hooks) {
     assert.equal(ability.get("canEdit"), true);
   });
 
+  test("can edit when user is accountant", function(assert) {
+    const ability = this.owner.lookup("ability:report");
+    ability.set("user", { isAccountant: true });
+
+    assert.equal(ability.get("canEdit"), true);
+  });
+
+  test("can edit when user is accountant and report is verified", function(assert) {
+    const ability = this.owner.lookup("ability:report");
+    ability.set("user", { isAccountant: true });
+    ability.set("model", { verifiedBy: { id: 1 } });
+
+    assert.equal(ability.get("canEdit"), true);
+  });
+
   test("can edit when user is superuser and report is verified", function(assert) {
     const ability = this.owner.lookup("ability:report");
     ability.set("user", { isSuperuser: true });

--- a/tests/unit/abilities/report-test.js
+++ b/tests/unit/abilities/report-test.js
@@ -11,21 +11,6 @@ module("Unit | Ability | report", function(hooks) {
     assert.equal(ability.get("canEdit"), true);
   });
 
-  test("can edit when user is accountant", function(assert) {
-    const ability = this.owner.lookup("ability:report");
-    ability.set("user", { isAccountant: true });
-
-    assert.equal(ability.get("canEdit"), true);
-  });
-
-  test("can edit when user is accountant and report is verified", function(assert) {
-    const ability = this.owner.lookup("ability:report");
-    ability.set("user", { isAccountant: true });
-    ability.set("model", { verifiedBy: { id: 1 } });
-
-    assert.equal(ability.get("canEdit"), true);
-  });
-
   test("can edit when user is superuser and report is verified", function(assert) {
     const ability = this.owner.lookup("ability:report");
     ability.set("user", { isSuperuser: true });


### PR DESCRIPTION
This will allow accountants to bill reports on analysis-edit. All
form elements except the `billed` checkbox will be disabled
if at least 1 report has been selected that was not created by the
accountant.