### PR TITLE
chore: run codemods

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -3,7 +3,7 @@
  * @submodule timed-adapters
  * @public
  */
-import DS from "ember-data";
+import JSONAPIAdapter from "@ember-data/adapter/json-api";
 import OIDCAdapterMixin from "ember-simple-auth-oidc/mixins/oidc-adapter-mixin";
 
 /**
@@ -14,6 +14,6 @@ import OIDCAdapterMixin from "ember-simple-auth-oidc/mixins/oidc-adapter-mixin";
  * @uses EmberSimpleAuthOIDC.OIDCAdapterMixin
  * @public
  */
-export default DS.JSONAPIAdapter.extend(OIDCAdapterMixin, {
-  namespace: "api/v1"
+export default JSONAPIAdapter.extend(OIDCAdapterMixin, {
+  namespace: "api/v1",
 });

--- a/app/analysis/index/controller.js
+++ b/app/analysis/index/controller.js
@@ -339,25 +339,25 @@ const AnalysisController = Controller.extend(AnalysisQueryParams.Mixin, {
       .join(",");
 
     const projectAssignees = projectIds.length
-      ? yield this.store.query("project-assignee", {
+      ? (yield this.store.query("project-assignee", {
           is_reviewer: 1,
           projects: projectIds,
           include: "project,user"
-        })
+        }))
       : [];
     const taskAssignees = taskIds.length
-      ? yield this.store.query("task-assignee", {
+      ? (yield this.store.query("task-assignee", {
           is_reviewer: 1,
           tasks: taskIds,
           include: "task,user"
-        })
+        }))
       : [];
     const customerAssignees = customerIds.length
-      ? yield this.store.query("customer-assignee", {
+      ? (yield this.store.query("customer-assignee", {
           is_reviewer: 1,
           customers: customerIds,
           include: "customer,user"
-        })
+        }))
       : [];
 
     return { projectAssignees, taskAssignees, customerAssignees };

--- a/app/components/attendance-slider/component.js
+++ b/app/components/attendance-slider/component.js
@@ -143,7 +143,7 @@ export default Component.extend({
         .minute(toMin)
     );
 
-    yield this.get("on-save")(attendance);
+    yield this["on-save"](attendance);
   }).drop(),
 
   /**
@@ -153,6 +153,6 @@ export default Component.extend({
    * @public
    */
   delete: task(function*() {
-    yield this.get("on-delete")(this.attendance);
+    yield this["on-delete"](this.attendance);
   }).drop()
 });

--- a/app/components/date-navigation/component.js
+++ b/app/components/date-navigation/component.js
@@ -38,7 +38,7 @@ export default Component.extend({
     setToday() {
       const date = moment();
 
-      this.get("on-change")(date);
+      this["on-change"](date);
     },
 
     /**
@@ -50,7 +50,7 @@ export default Component.extend({
     setPrevious() {
       const date = moment(this.current).subtract(1, "days");
 
-      this.get("on-change")(date);
+      this["on-change"](date);
     },
 
     /**
@@ -62,7 +62,7 @@ export default Component.extend({
     setNext() {
       const date = moment(this.current).add(1, "days");
 
-      this.get("on-change")(date);
+      this["on-change"](date);
     }
   }
 });

--- a/app/components/record-button/component.js
+++ b/app/components/record-button/component.js
@@ -57,7 +57,7 @@ export default Component.extend({
      * @public
      */
     start() {
-      this.get("on-start")();
+      this["on-start"]();
     },
 
     /**
@@ -67,7 +67,7 @@ export default Component.extend({
      * @public
      */
     stop() {
-      this.get("on-stop")();
+      this["on-stop"]();
     }
   }
 });

--- a/app/components/report-row/component.js
+++ b/app/components/report-row/component.js
@@ -78,7 +78,7 @@ const ReportRowComponent = Component.extend({
      * @public
      */
     save() {
-      this.get("on-save")(this.changeset);
+      this["on-save"](this.changeset);
     },
 
     /**
@@ -88,7 +88,7 @@ const ReportRowComponent = Component.extend({
      * @public
      */
     delete() {
-      this.get("on-delete")(this.report);
+      this["on-delete"](this.report);
     }
   }
 });

--- a/app/components/statistic-list/component.js
+++ b/app/components/statistic-list/component.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import Component from "@ember/component";
 import { get, computed } from "@ember/object";
 import { capitalize } from "@ember/string";
-import hbs from "htmlbars-inline-precompile";
 import moment from "moment";
 import parseDjangoDuration from "timed/utils/parse-django-duration";
 

--- a/app/components/sy-datepicker/component.js
+++ b/app/components/sy-datepicker/component.js
@@ -15,7 +15,7 @@ export default Component.extend({
   placeholder: DISPLAY_FORMAT,
 
   displayValue: computed("value", function() {
-    const value = this.get("value");
+    const value = this.value;
     return value && value.isValid() ? value.format(DISPLAY_FORMAT) : null;
   }),
 
@@ -42,7 +42,7 @@ export default Component.extend({
 
       // eslint-disable-next-line ember/no-incorrect-calls-with-inline-anonymous-functions
       scheduleOnce("afterRender", this, function() {
-        const target = this.get("element").querySelector(
+        const target = this.element.querySelector(
           ".ember-basic-dropdown-trigger input"
         );
 
@@ -65,7 +65,7 @@ export default Component.extend({
       if (valid) {
         const parsed = parse(value);
 
-        return this.get("on-change")(
+        return this["on-change"](
           parsed && parsed.isValid() ? parsed : null
         );
       }

--- a/app/components/sy-modal/overlay/component.js
+++ b/app/components/sy-modal/overlay/component.js
@@ -38,7 +38,7 @@ export default Component.extend({
    */
   click(e) {
     if (e.target === this.element) {
-      this.get("on-close")();
+      this["on-close"]();
     }
   }
 });

--- a/app/components/sy-timepicker/component.js
+++ b/app/components/sy-timepicker/component.js
@@ -277,7 +277,7 @@ export default Component.extend({
    * @private
    */
   _change(value) {
-    this.get("on-change")(value);
+    this["on-change"](value);
   },
 
   /**

--- a/app/components/task-selection/component.js
+++ b/app/components/task-selection/component.js
@@ -1,3 +1,4 @@
+import { hbs } from 'ember-cli-htmlbars';
 /**
  * @module timed
  * @submodule timed-components
@@ -7,7 +8,6 @@ import Component from "@ember/component";
 import { computed } from "@ember/object";
 import { later } from "@ember/runloop";
 import { inject as service } from "@ember/service";
-import hbs from "htmlbars-inline-precompile";
 import { resolve } from "rsvp";
 import customerOptionTemplate from "timed/templates/customer-option";
 import projectOptionTemplate from "timed/templates/project-option";

--- a/app/components/user-selection/component.js
+++ b/app/components/user-selection/component.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import Component from "@ember/component";
 import { computed } from "@ember/object";
 import { inject as service } from "@ember/service";
-import hbs from "htmlbars-inline-precompile";
 
 const SELECTED_TEMPLATE = hbs`{{selected.longName}}`;
 

--- a/app/components/weekly-overview-day/component.js
+++ b/app/components/weekly-overview-day/component.js
@@ -119,12 +119,12 @@ export default Component.extend({
    * Click event - fire the on-click action
    */
   click(event) {
-    const action = this.get("on-click");
+    const action = this["on-click"];
 
     if (action) {
       event.preventDefault();
 
-      this.get("on-click")(this.day);
+      this["on-click"](this.day);
     }
   }
 });

--- a/app/index/route.js
+++ b/app/index/route.js
@@ -117,7 +117,7 @@ export default Route.extend(RouteAutostartTourMixin, {
     this._super(controller, model, ...args);
 
     controller.set("user", this.modelFor("protected"));
-    controller.get("setCenter").perform({ moment: model });
+    controller.setCenter.perform({ moment: model });
 
     controller.set("newAbsence", {
       dates: [model],

--- a/app/models/absence-balance.js
+++ b/app/models/absence-balance.js
@@ -1,6 +1,4 @@
-import attr from "ember-data/attr";
-import Model from "ember-data/model";
-import { belongsTo, hasMany } from "ember-data/relationships";
+import Model, { attr, belongsTo, hasMany } from "@ember-data/model";
 
 export default Model.extend({
   credit: attr("number"),
@@ -9,5 +7,5 @@ export default Model.extend({
   balance: attr("number"),
   user: belongsTo("user"),
   absenceType: belongsTo("absence-type"),
-  absenceCredits: hasMany("absence-credit")
+  absenceCredits: hasMany("absence-credit"),
 });

--- a/app/models/absence-credit.js
+++ b/app/models/absence-credit.js
@@ -3,9 +3,7 @@
  * @submodule timed-models
  * @public
  */
-import attr from "ember-data/attr";
-import Model from "ember-data/model";
-import { belongsTo } from "ember-data/relationships";
+import Model, { attr, belongsTo } from "@ember-data/model";
 
 /**
  * The absence credit model
@@ -53,5 +51,5 @@ export default Model.extend({
    * @property {User} user
    * @public
    */
-  user: belongsTo("user")
+  user: belongsTo("user"),
 });

--- a/app/models/absence-type.js
+++ b/app/models/absence-type.js
@@ -3,9 +3,7 @@
  * @submodule timed-models
  * @public
  */
-import attr from "ember-data/attr";
-import Model from "ember-data/model";
-import { hasMany } from "ember-data/relationships";
+import Model, { attr, hasMany } from "@ember-data/model";
 
 /**
  * The absence type model
@@ -39,5 +37,5 @@ export default Model.extend({
    * @property {AbsenceBalance[]} absenceBalances
    * @public
    */
-  absenceBalances: hasMany("absence-balance")
+  absenceBalances: hasMany("absence-balance"),
 });

--- a/app/models/absence.js
+++ b/app/models/absence.js
@@ -3,9 +3,7 @@
  * @submodule timed-models
  * @public
  */
-import attr from "ember-data/attr";
-import Model from "ember-data/model";
-import { belongsTo } from "ember-data/relationships";
+import Model, { attr, belongsTo } from "@ember-data/model";
 import moment from "moment";
 
 /**
@@ -54,5 +52,5 @@ export default Model.extend({
    * @property {User} user
    * @public
    */
-  user: belongsTo("user")
+  user: belongsTo("user"),
 });

--- a/app/models/activity.js
+++ b/app/models/activity.js
@@ -3,11 +3,9 @@
  * @submodule timed-models
  * @public
  */
+import Model, { attr, belongsTo } from "@ember-data/model";
 import { computed } from "@ember/object";
 import { inject as service } from "@ember/service";
-import attr from "ember-data/attr";
-import Model from "ember-data/model";
-import { belongsTo } from "ember-data/relationships";
 import moment from "moment";
 import { all } from "rsvp";
 
@@ -91,11 +89,11 @@ export default Model.extend({
    * @type {Boolean}
    * @public
    */
-  active: computed("toTime", function() {
+  active: computed("id", "toTime", function () {
     return !this.toTime && !!this.id;
   }),
 
-  duration: computed("fromTime", "toTime", function() {
+  duration: computed("from", "fromTime", "to", "toTime", function () {
     return moment.duration((this.to ? this.to : moment()).diff(this.from));
   }),
 
@@ -108,14 +106,14 @@ export default Model.extend({
           h: time.hours(),
           m: time.minutes(),
           s: time.seconds(),
-          ms: time.milliseconds()
+          ms: time.milliseconds(),
         })
       );
     },
     set(key, val) {
       this.set("fromTime", val);
       return val;
-    }
+    },
   }),
 
   to: computed("date", "toTime", {
@@ -127,14 +125,14 @@ export default Model.extend({
           h: time.hours(),
           m: time.minutes(),
           s: time.seconds(),
-          ms: time.milliseconds()
+          ms: time.milliseconds(),
         })
       );
     },
     set(key, val) {
       this.set("toTime", val);
       return val;
-    }
+    },
   }),
 
   /**
@@ -150,7 +148,7 @@ export default Model.extend({
       task: this.task,
       comment: this.comment,
       review: this.review,
-      notBillable: this.notBillable
+      notBillable: this.notBillable,
     });
 
     await activity.save();
@@ -187,13 +185,13 @@ export default Model.extend({
           date: moment(this.date).add(1, "days"),
           review: this.review,
           notBillable: this.notBillable,
-          fromTime: moment({ h: 0, m: 0, s: 0 })
+          fromTime: moment({ h: 0, m: 0, s: 0 }),
         })
       );
     }
 
     await all(
-      activities.map(async activity => {
+      activities.map(async (activity) => {
         if (activity.get("isNew")) {
           await activity.save();
         }
@@ -205,7 +203,7 @@ export default Model.extend({
               moment(activity.get("date")).set({
                 h: 23,
                 m: 59,
-                s: 59
+                s: 59,
               }),
               moment()
             )
@@ -222,5 +220,5 @@ export default Model.extend({
         { closeAfter: 5000 }
       );
     }
-  }
+  },
 });

--- a/app/models/attendance.js
+++ b/app/models/attendance.js
@@ -3,10 +3,8 @@
  * @submodule timed-models
  * @public
  */
+import Model, { attr, belongsTo } from "@ember-data/model";
 import { computed } from "@ember/object";
-import attr from "ember-data/attr";
-import Model from "ember-data/model";
-import { belongsTo } from "ember-data/relationships";
 import moment from "moment";
 
 /**
@@ -59,12 +57,12 @@ export default Model.extend({
    * @property {moment.duration} duration
    * @public
    */
-  duration: computed("from", "to", function() {
+  duration: computed("from", "to", function () {
     const calcTo =
       this.to.format("HH:mm") === "00:00"
         ? this.to.clone().add(1, "day")
         : this.to;
 
     return moment.duration(calcTo.diff(this.from));
-  })
+  }),
 });

--- a/app/models/billing-type.js
+++ b/app/models/billing-type.js
@@ -3,8 +3,7 @@
  * @submodule timed-models
  * @public
  */
-import attr from "ember-data/attr";
-import Model from "ember-data/model";
+import Model, { attr } from "@ember-data/model";
 
 /**
  * The billing type model
@@ -20,5 +19,5 @@ export default Model.extend({
    * @property {String} name
    * @public
    */
-  name: attr("string")
+  name: attr("string"),
 });

--- a/app/models/cost-center.js
+++ b/app/models/cost-center.js
@@ -1,7 +1,6 @@
-import attr from "ember-data/attr";
-import Model from "ember-data/model";
+import Model, { attr } from "@ember-data/model";
 
 export default Model.extend({
   name: attr("string"),
-  reference: attr("string")
+  reference: attr("string"),
 });

--- a/app/models/customer-assignee.js
+++ b/app/models/customer-assignee.js
@@ -3,9 +3,7 @@
  * @submodule timed-models
  * @public
  */
-import attr from "ember-data/attr";
-import Model from "ember-data/model";
-import { belongsTo } from "ember-data/relationships";
+import Model, { attr, belongsTo } from "@ember-data/model";
 
 /**
  * The customer assignee model
@@ -57,5 +55,5 @@ export default Model.extend({
    * @type {Boolean}
    * @public
    */
-  isResource: attr("boolean", { defaultValue: false })
+  isResource: attr("boolean", { defaultValue: false }),
 });

--- a/app/models/customer-statistic.js
+++ b/app/models/customer-statistic.js
@@ -1,8 +1,6 @@
-import attr from "ember-data/attr";
-import Model from "ember-data/model";
-import { belongsTo } from "ember-data/relationships";
+import Model, { attr, belongsTo } from "@ember-data/model";
 
 export default Model.extend({
   duration: attr("django-duration"),
-  customer: belongsTo("customer")
+  customer: belongsTo("customer"),
 });

--- a/app/models/customer.js
+++ b/app/models/customer.js
@@ -3,10 +3,8 @@
  * @submodule timed-models
  * @public
  */
+import Model, { attr, hasMany } from "@ember-data/model";
 import { reads } from "@ember/object/computed";
-import attr from "ember-data/attr";
-import Model from "ember-data/model";
-import { hasMany } from "ember-data/relationships";
 
 /**
  * The customer model
@@ -58,7 +56,7 @@ const Customer = Model.extend({
    * @type {CustomerAssignee[]}
    * @public
    */
-  assignees: hasMany("customer-assignee")
+  assignees: hasMany("customer-assignee"),
 });
 
 export default Customer;

--- a/app/models/employment.js
+++ b/app/models/employment.js
@@ -3,9 +3,7 @@
  * @submodule timed-models
  * @public
  */
-import attr from "ember-data/attr";
-import Model from "ember-data/model";
-import { belongsTo } from "ember-data/relationships";
+import Model, { attr, belongsTo } from "@ember-data/model";
 
 /**
  * The employment model
@@ -69,5 +67,5 @@ export default Model.extend({
    * @property {Location} location
    * @public
    */
-  location: belongsTo("location")
+  location: belongsTo("location"),
 });

--- a/app/models/location.js
+++ b/app/models/location.js
@@ -3,8 +3,7 @@
  * @submodule timed-models
  * @public
  */
-import attr from "ember-data/attr";
-import Model from "ember-data/model";
+import Model, { attr } from "@ember-data/model";
 
 /**
  * The location model
@@ -28,5 +27,5 @@ export default Model.extend({
    * @property {Number[]} workdays
    * @public
    */
-  workdays: attr("django-workdays")
+  workdays: attr("django-workdays"),
 });

--- a/app/models/month-statistic.js
+++ b/app/models/month-statistic.js
@@ -1,8 +1,7 @@
-import attr from "ember-data/attr";
-import Model from "ember-data/model";
+import Model, { attr } from "@ember-data/model";
 
 export default Model.extend({
   year: attr("number"),
   month: attr("number"),
-  duration: attr("django-duration")
+  duration: attr("django-duration"),
 });

--- a/app/models/overtime-credit.js
+++ b/app/models/overtime-credit.js
@@ -1,10 +1,8 @@
-import attr from "ember-data/attr";
-import Model from "ember-data/model";
-import { belongsTo } from "ember-data/relationships";
+import Model, { attr, belongsTo } from "@ember-data/model";
 
 export default Model.extend({
   date: attr("django-date"),
   duration: attr("django-duration"),
   comment: attr("string", { defaultValue: "" }),
-  user: belongsTo("user")
+  user: belongsTo("user"),
 });

--- a/app/models/project-assignee.js
+++ b/app/models/project-assignee.js
@@ -3,9 +3,7 @@
  * @submodule timed-models
  * @public
  */
-import attr from "ember-data/attr";
-import Model from "ember-data/model";
-import { belongsTo } from "ember-data/relationships";
+import Model, { attr, belongsTo } from "@ember-data/model";
 
 /**
  * The project assignee model
@@ -58,5 +56,5 @@ export default Model.extend({
    * @type {Boolean}
    * @public
    */
-  isResource: attr("boolean", { defaultValue: false })
+  isResource: attr("boolean", { defaultValue: false }),
 });

--- a/app/models/project-statistic.js
+++ b/app/models/project-statistic.js
@@ -1,8 +1,6 @@
-import attr from "ember-data/attr";
-import Model from "ember-data/model";
-import { belongsTo } from "ember-data/relationships";
+import Model, { attr, belongsTo } from "@ember-data/model";
 
 export default Model.extend({
   duration: attr("django-duration"),
-  project: belongsTo("project")
+  project: belongsTo("project"),
 });

--- a/app/models/project.js
+++ b/app/models/project.js
@@ -3,9 +3,7 @@
  * @submodule timed-models
  * @public
  */
-import attr from "ember-data/attr";
-import Model from "ember-data/model";
-import { belongsTo, hasMany } from "ember-data/relationships";
+import Model, { attr, belongsTo, hasMany } from "@ember-data/model";
 
 /**
  * The project model
@@ -83,5 +81,5 @@ export default Model.extend({
    * @type {ProjectAssignee[]}
    * @public
    */
-  assignees: hasMany("project-assignee")
+  assignees: hasMany("project-assignee"),
 });

--- a/app/models/public-holiday.js
+++ b/app/models/public-holiday.js
@@ -3,9 +3,7 @@
  * @submodule timed-models
  * @public
  */
-import attr from "ember-data/attr";
-import Model from "ember-data/model";
-import { belongsTo } from "ember-data/relationships";
+import Model, { attr, belongsTo } from "@ember-data/model";
 
 /**
  * The public holiday model
@@ -37,5 +35,5 @@ export default Model.extend({
    * @property {Location} location
    * @public
    */
-  location: belongsTo("location")
+  location: belongsTo("location"),
 });

--- a/app/models/report-intersection.js
+++ b/app/models/report-intersection.js
@@ -1,6 +1,4 @@
-import attr from "ember-data/attr";
-import Model from "ember-data/model";
-import { belongsTo } from "ember-data/relationships";
+import Model, { attr, belongsTo } from "@ember-data/model";
 
 export default Model.extend({
   comment: attr("string"),
@@ -12,5 +10,5 @@ export default Model.extend({
   customer: belongsTo("customer"),
   project: belongsTo("project"),
   task: belongsTo("task"),
-  user: belongsTo("user")
+  user: belongsTo("user"),
 });

--- a/app/models/report.js
+++ b/app/models/report.js
@@ -3,26 +3,24 @@
  * @submodule timed-models
  * @public
  */
-import attr from "ember-data/attr";
-import Model from "ember-data/model";
-import { belongsTo } from "ember-data/relationships";
+import Model, { attr, belongsTo } from "@ember-data/model";
 import moment from "moment";
 
 /**
  * The report model
  *
  * @class Report
- * @extends DS.Model
+ * @extends Model
  * @public
  */
-export default Model.extend({
+export default class Report extends Model {
   /**
    * The comment
    *
    * @property {String} comment
    * @public
    */
-  comment: attr("string", { defaultValue: "" }),
+  @attr("string", { defaultValue: "" }) comment;
 
   /**
    * The date
@@ -30,7 +28,7 @@ export default Model.extend({
    * @property {moment} date
    * @public
    */
-  date: attr("django-date"),
+  @attr("django-date") date;
 
   /**
    * The duration
@@ -38,7 +36,7 @@ export default Model.extend({
    * @property {moment.duration} duration
    * @public
    */
-  duration: attr("django-duration", { defaultValue: () => moment.duration() }),
+  @attr("django-duration", { defaultValue: () => moment.duration() }) duration;
 
   /**
    * Whether the report needs to be reviewed
@@ -46,7 +44,7 @@ export default Model.extend({
    * @property {Boolean} review
    * @public
    */
-  review: attr("boolean", { defaultValue: false }),
+  @attr("boolean", { defaultValue: false }) review;
 
   /**
    * Whether the report is not billable
@@ -54,7 +52,7 @@ export default Model.extend({
    * @property {Boolean} notBillable
    * @public
    */
-  notBillable: attr("boolean", { defaultValue: false }),
+  @attr("boolean", { defaultValue: false }) notBillable;
 
   /**
    * Whether the report has been marked as billed
@@ -62,7 +60,7 @@ export default Model.extend({
    * @property {Boolean} billed
    * @public
    */
-  billed: attr("boolean", { defaultValue: false }),
+  @attr("boolean", { defaultValue: false }) billed;
 
   /**
    * The task
@@ -70,7 +68,7 @@ export default Model.extend({
    * @property {Task} task
    * @public
    */
-  task: belongsTo("task"),
+  @belongsTo("task") task;
 
   /**
    * The user
@@ -78,7 +76,7 @@ export default Model.extend({
    * @property {User} user
    * @public
    */
-  user: belongsTo("user"),
+  @belongsTo("user") user;
 
   /**
    * The user which verified this report
@@ -86,5 +84,5 @@ export default Model.extend({
    * @property {User} verifiedBy
    * @public
    */
-  verifiedBy: belongsTo("user")
-});
+  @belongsTo("user") verifiedBy;
+}

--- a/app/models/task-assignee.js
+++ b/app/models/task-assignee.js
@@ -3,9 +3,7 @@
  * @submodule timed-models
  * @public
  */
-import attr from "ember-data/attr";
-import Model from "ember-data/model";
-import { belongsTo } from "ember-data/relationships";
+import Model, { attr, belongsTo } from "@ember-data/model";
 
 /**
  * The task assignee model
@@ -57,5 +55,5 @@ export default Model.extend({
    * @type {Boolean}
    * @public
    */
-  isResource: attr("boolean", { defaultValue: false })
+  isResource: attr("boolean", { defaultValue: false }),
 });

--- a/app/models/task-statistic.js
+++ b/app/models/task-statistic.js
@@ -1,8 +1,6 @@
-import attr from "ember-data/attr";
-import Model from "ember-data/model";
-import { belongsTo } from "ember-data/relationships";
+import Model, { attr, belongsTo } from "@ember-data/model";
 
 export default Model.extend({
   duration: attr("django-duration"),
-  task: belongsTo("task")
+  task: belongsTo("task"),
 });

--- a/app/models/task.js
+++ b/app/models/task.js
@@ -3,19 +3,16 @@
  * @submodule timed-models
  * @public
  */
-import { computed } from "@ember/object";
-import attr from "ember-data/attr";
-import Model from "ember-data/model";
-import { belongsTo, hasMany } from "ember-data/relationships";
+import Model, { attr, belongsTo, hasMany } from "@ember-data/model";
 
 /**
  * The task model
  *
  * @class Task
- * @extends DS.Model
+ * @extends Model
  * @public
  */
-export default Model.extend({
+export default class Task extends Model {
   /**
    * The name
    *
@@ -23,7 +20,7 @@ export default Model.extend({
    * @type {String}
    * @public
    */
-  name: attr("string", { defaultValue: "" }),
+  @attr("string", { defaultValue: "" }) name;
 
   /**
    * The estimated time
@@ -31,7 +28,7 @@ export default Model.extend({
    * @property {moment.duration} estimatedTime
    * @public
    */
-  estimatedTime: attr("django-duration"),
+  @attr("django-duration") estimatedTime;
 
   /**
    * Whether the task is archived
@@ -40,9 +37,9 @@ export default Model.extend({
    * @type {Boolean}
    * @public
    */
-  archived: attr("boolean", { defaultValue: false }),
+  @attr("boolean", { defaultValue: false }) archived;
 
-  reference: attr("string", { defaultValue: "" }),
+  @attr("string", { defaultValue: "" }) reference;
 
   /**
    * The project
@@ -51,7 +48,7 @@ export default Model.extend({
    * @type {Project}
    * @public
    */
-  project: belongsTo("project"),
+  @belongsTo("project") project;
 
   /**
    * Assigned users to this task
@@ -60,7 +57,7 @@ export default Model.extend({
    * @type {TaskAssignee[]}
    * @public
    */
-  assignees: hasMany("task-assignee"),
+  @hasMany("task-assignee") assignees;
 
   /**
    * Flag saying that this is a task.
@@ -72,13 +69,13 @@ export default Model.extend({
    * @type {Project}
    * @public
    */
-  isTask: true,
+  isTask = true;
 
-  longName: computed("project", function() {
+  get longName() {
     const taskName = this.name;
-    const projectName = this.get("project.name");
-    const customerName = this.get("project.customer.name");
+    const projectName = this.project?.name;
+    const customerName = this.project?.customer?.name;
 
     return `${customerName} > ${projectName} > ${taskName}`;
-  })
-});
+  }
+}

--- a/app/models/user-statistic.js
+++ b/app/models/user-statistic.js
@@ -1,8 +1,6 @@
-import attr from "ember-data/attr";
-import Model from "ember-data/model";
-import { belongsTo } from "ember-data/relationships";
+import Model, { attr, belongsTo } from "@ember-data/model";
 
 export default Model.extend({
   duration: attr("django-duration"),
-  user: belongsTo("user")
+  user: belongsTo("user"),
 });

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -3,10 +3,8 @@
  * @submodule timed-models
  * @public
  */
+import Model, { attr, hasMany } from "@ember-data/model";
 import { computed } from "@ember/object";
-import attr from "ember-data/attr";
-import Model from "ember-data/model";
-import { hasMany } from "ember-data/relationships";
 import moment from "moment";
 
 /**
@@ -134,7 +132,7 @@ export default Model.extend({
    * @property {String} fullName
    * @public
    */
-  fullName: computed("firstName", "lastName", function() {
+  fullName: computed("firstName", "lastName", function () {
     if (!this.firstName && !this.lastName) {
       return "";
     }
@@ -151,7 +149,7 @@ export default Model.extend({
    * @property {String} longName
    * @public
    */
-  longName: computed("username", "fullName", function() {
+  longName: computed("username", "fullName", function () {
     return this.fullName
       ? `${this.fullName} (${this.username})`
       : this.username;
@@ -165,9 +163,9 @@ export default Model.extend({
    * @property {Employment} activeEmployment
    * @public
    */
-  activeEmployment: computed("employments.[]", function() {
+  activeEmployment: computed("employments.[]", "id", "store", function () {
     return (
-      this.store.peekAll("employment").find(e => {
+      this.store.peekAll("employment").find((e) => {
         return (
           e.get("user.id") === this.id &&
           (!e.get("end") || e.get("end").isSameOrAfter(moment.now(), "day"))
@@ -182,14 +180,19 @@ export default Model.extend({
    * @property {WorktimeBalance} currentWorktimeBalance
    * @public
    */
-  currentWorktimeBalance: computed("worktimeBalances.[]", function() {
-    return (
-      this.store.peekAll("worktime-balance").find(balance => {
-        return (
-          balance.get("user.id") === this.id &&
-          balance.get("date").isSame(moment(), "day")
-        );
-      }) || null
-    );
-  })
+  currentWorktimeBalance: computed(
+    "id",
+    "store",
+    "worktimeBalances.[]",
+    function () {
+      return (
+        this.store.peekAll("worktime-balance").find((balance) => {
+          return (
+            balance.get("user.id") === this.id &&
+            balance.get("date").isSame(moment(), "day")
+          );
+        }) || null
+      );
+    }
+  ),
 });

--- a/app/models/worktime-balance.js
+++ b/app/models/worktime-balance.js
@@ -1,9 +1,7 @@
-import attr from "ember-data/attr";
-import Model from "ember-data/model";
-import { belongsTo } from "ember-data/relationships";
+import Model, { attr, belongsTo } from "@ember-data/model";
 
 export default Model.extend({
   date: attr("django-date"),
   balance: attr("django-duration"),
-  user: belongsTo("user")
+  user: belongsTo("user"),
 });

--- a/app/models/year-statistic.js
+++ b/app/models/year-statistic.js
@@ -1,7 +1,6 @@
-import attr from "ember-data/attr";
-import Model from "ember-data/model";
+import Model, { attr } from "@ember-data/model";
 
 export default Model.extend({
   year: attr("number"),
-  duration: attr("django-duration")
+  duration: attr("django-duration"),
 });

--- a/app/projects/controller.js
+++ b/app/projects/controller.js
@@ -75,9 +75,9 @@ export default Controller.extend({
   createTask: task(function*() {
     this.set(
       "selectedTask",
-      yield this.store.createRecord("task", {
+      (yield this.store.createRecord("task", {
         project: this.selectedProject
-      })
+      }))
     );
   }).drop(),
 

--- a/app/serializers/application.js
+++ b/app/serializers/application.js
@@ -3,7 +3,7 @@
  * @submodule timed-serializers
  * @public
  */
-import JSONAPISerializer from "ember-data/serializers/json-api";
+import JSONAPISerializer from "@ember-data/serializer/json-api";
 
 /**
  * The application serializer

--- a/app/transforms/django-duration.js
+++ b/app/transforms/django-duration.js
@@ -3,7 +3,7 @@
  * @submodule timed-transforms
  * @public
  */
-import Transform from "ember-data/transform";
+import Transform from "@ember-data/serializer/transform";
 import { padTpl, padStart } from "ember-pad/utils/pad";
 import moment from "moment";
 import parseDjangoDuration from "timed/utils/parse-django-duration";
@@ -63,7 +63,7 @@ export default Transform.extend({
       hours: positiveDuration.hours(),
       minutes: positiveDuration.minutes(),
       seconds: positiveDuration.seconds(),
-      microseconds: round(positiveDuration.milliseconds() * 1000)
+      microseconds: round(positiveDuration.milliseconds() * 1000),
     };
   },
 
@@ -80,13 +80,8 @@ export default Transform.extend({
       return null;
     }
 
-    const {
-      days,
-      hours,
-      minutes,
-      seconds,
-      microseconds
-    } = this._getDurationComponentsTimedeltaLike(deserialized);
+    const { days, hours, minutes, seconds, microseconds } =
+      this._getDurationComponentsTimedeltaLike(deserialized);
 
     let string = padTpl2`${hours}:${minutes}:${seconds}`;
 
@@ -99,5 +94,5 @@ export default Transform.extend({
     }
 
     return string;
-  }
+  },
 });

--- a/app/transforms/django-workdays.js
+++ b/app/transforms/django-workdays.js
@@ -3,9 +3,7 @@
  * @submodule timed-transforms
  * @public
  */
-import DS from "ember-data";
-
-const { Transform } = DS;
+import Transform from "@ember-data/serializer/transform";
 
 /**
  * Django worktime transform
@@ -39,5 +37,5 @@ export default Transform.extend({
    */
   serialize(deserialized) {
     return deserialized.map(String);
-  }
+  },
 });

--- a/app/transforms/moment.js
+++ b/app/transforms/moment.js
@@ -3,10 +3,8 @@
  * @submodule timed-transforms
  * @public
  */
-import DS from "ember-data";
+import Transform from "@ember-data/serializer/transform";
 import moment from "moment";
-
-const { Transform } = DS;
 
 /**
  * The moment transform
@@ -50,5 +48,5 @@ export default Transform.extend({
     return deserialized && deserialized.isValid()
       ? deserialized.format(this.format)
       : null;
-  }
+  },
 });

--- a/app/users/edit/credits/absence-credits/edit/controller.js
+++ b/app/users/edit/credits/absence-credits/edit/controller.js
@@ -22,12 +22,12 @@ export default Controller.extend({
     const id = this.model;
 
     return id
-      ? yield this.store.findRecord("absence-credit", id, {
+      ? (yield this.store.findRecord("absence-credit", id, {
           include: "absence_type"
-        })
-      : yield this.store.createRecord("absence-credit", {
+        }))
+      : (yield this.store.createRecord("absence-credit", {
           user: this.user
-        });
+        }));
   }),
 
   save: task(function*(changeset) {

--- a/app/users/edit/credits/absence-credits/edit/route.js
+++ b/app/users/edit/credits/absence-credits/edit/route.js
@@ -7,7 +7,7 @@ export default Route.extend({
     this._super(controller, ...args);
 
     controller.set("user", this.modelFor("users.edit"));
-    controller.get("absenceTypes").perform();
-    controller.get("credit").perform();
+    controller.absenceTypes.perform();
+    controller.credit.perform();
   }
 });

--- a/app/users/edit/credits/absence-credits/new/route.js
+++ b/app/users/edit/credits/absence-credits/new/route.js
@@ -13,7 +13,7 @@ export default Route.extend({
     this._super(controller, ...args);
 
     controller.set("user", this.modelFor("users.edit"));
-    controller.get("absenceTypes").perform();
-    controller.get("credit").perform();
+    controller.absenceTypes.perform();
+    controller.credit.perform();
   }
 });

--- a/app/users/edit/credits/overtime-credits/edit/controller.js
+++ b/app/users/edit/credits/overtime-credits/edit/controller.js
@@ -16,10 +16,10 @@ export default Controller.extend({
     const id = this.model;
 
     return id
-      ? yield this.store.findRecord("overtime-credit", id)
-      : yield this.store.createRecord("overtime-credit", {
+      ? (yield this.store.findRecord("overtime-credit", id))
+      : (yield this.store.createRecord("overtime-credit", {
           user: this.user
-        });
+        }));
   }),
 
   save: task(function*(changeset) {

--- a/app/users/edit/credits/overtime-credits/edit/route.js
+++ b/app/users/edit/credits/overtime-credits/edit/route.js
@@ -7,6 +7,6 @@ export default Route.extend({
     this._super(controller, ...args);
 
     controller.set("user", this.modelFor("users.edit"));
-    controller.get("credit").perform();
+    controller.credit.perform();
   }
 });

--- a/app/users/edit/credits/overtime-credits/new/route.js
+++ b/app/users/edit/credits/overtime-credits/new/route.js
@@ -13,6 +13,6 @@ export default Route.extend({
     this._super(controller, ...args);
 
     controller.set("user", this.modelFor("users.edit"));
-    controller.get("credit").perform();
+    controller.credit.perform();
   }
 });

--- a/tests/integration/components/async-list/component-test.js
+++ b/tests/integration/components/async-list/component-test.js
@@ -1,6 +1,6 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import { module, test } from "qunit";
 
 module("Integration | Component | async list", function(hooks) {

--- a/tests/integration/components/attendance-slider/component-test.js
+++ b/tests/integration/components/attendance-slider/component-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from "@ember/object";
 import { click, render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import moment from "moment";
 import { module, test } from "qunit";
 

--- a/tests/integration/components/balance-donut/component-test.js
+++ b/tests/integration/components/balance-donut/component-test.js
@@ -1,6 +1,6 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { find, render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import moment from "moment";
 import { module, test } from "qunit";
 

--- a/tests/integration/components/changed-warning/component-test.js
+++ b/tests/integration/components/changed-warning/component-test.js
@@ -1,6 +1,6 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import { module, test } from "qunit";
 
 module("Integration | Component | changed warning", function(hooks) {

--- a/tests/integration/components/customer-visible-icon/component-test.js
+++ b/tests/integration/components/customer-visible-icon/component-test.js
@@ -1,6 +1,6 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import { module, test } from "qunit";
 
 module("Integration | Component | customer visible icon", function(hooks) {

--- a/tests/integration/components/date-buttons/component-test.js
+++ b/tests/integration/components/date-buttons/component-test.js
@@ -1,6 +1,6 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { click, render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import moment from "moment";
 import { module, test } from "qunit";
 

--- a/tests/integration/components/date-navigation/component-test.js
+++ b/tests/integration/components/date-navigation/component-test.js
@@ -1,6 +1,6 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { click, render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import moment from "moment";
 import { module, test } from "qunit";
 

--- a/tests/integration/components/duration-since/component-test.js
+++ b/tests/integration/components/duration-since/component-test.js
@@ -1,6 +1,6 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import moment from "moment";
 import { module, test } from "qunit";
 

--- a/tests/integration/components/filter-sidebar/component-test.js
+++ b/tests/integration/components/filter-sidebar/component-test.js
@@ -1,6 +1,6 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { click, render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import { module, test } from "qunit";
 
 module("Integration | Component | filter sidebar", function(hooks) {

--- a/tests/integration/components/filter-sidebar/filter/component-test.js
+++ b/tests/integration/components/filter-sidebar/filter/component-test.js
@@ -1,6 +1,6 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { click, findAll, find, fillIn, render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import moment from "moment";
 import { module, test } from "qunit";
 

--- a/tests/integration/components/filter-sidebar/group/component-test.js
+++ b/tests/integration/components/filter-sidebar/group/component-test.js
@@ -1,6 +1,6 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { click, render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import { module, test } from "qunit";
 
 module("Integration | Component | filter sidebar/group", function(hooks) {

--- a/tests/integration/components/filter-sidebar/label/component-test.js
+++ b/tests/integration/components/filter-sidebar/label/component-test.js
@@ -1,6 +1,6 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import { module, test } from "qunit";
 
 module("Integration | Component | filter sidebar/label", function(hooks) {

--- a/tests/integration/components/in-viewport/component-test.js
+++ b/tests/integration/components/in-viewport/component-test.js
@@ -1,6 +1,6 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import { module, test } from "qunit";
 
 module("Integration | Component | in viewport", function(hooks) {

--- a/tests/integration/components/loading-icon/component-test.js
+++ b/tests/integration/components/loading-icon/component-test.js
@@ -1,6 +1,6 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import { module, test } from "qunit";
 
 module("Integration | Component | loading icon", function(hooks) {

--- a/tests/integration/components/no-mobile-message/component-test.js
+++ b/tests/integration/components/no-mobile-message/component-test.js
@@ -1,6 +1,6 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import { module, test } from "qunit";
 
 module("Integration | Component | no mobile message", function(hooks) {

--- a/tests/integration/components/no-permission/component-test.js
+++ b/tests/integration/components/no-permission/component-test.js
@@ -1,6 +1,6 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import { module, test } from "qunit";
 
 module("Integration | Component | no permission", function(hooks) {

--- a/tests/integration/components/not-identical-warning/component-test.js
+++ b/tests/integration/components/not-identical-warning/component-test.js
@@ -1,6 +1,6 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import { module, test } from "qunit";
 
 module("Integration | Component | not identical warning", function(hooks) {

--- a/tests/integration/components/paginated-table/body/component-test.js
+++ b/tests/integration/components/paginated-table/body/component-test.js
@@ -1,6 +1,6 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import { module, test } from "qunit";
 
 module("Integration | Component | paginated table/body", function(hooks) {

--- a/tests/integration/components/paginated-table/component-test.js
+++ b/tests/integration/components/paginated-table/component-test.js
@@ -1,6 +1,6 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import { module, test } from "qunit";
 
 module("Integration | Component | paginated table", function(hooks) {

--- a/tests/integration/components/paginated-table/foot/component-test.js
+++ b/tests/integration/components/paginated-table/foot/component-test.js
@@ -1,6 +1,6 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import { module, test } from "qunit";
 
 module("Integration | Component | paginated table/foot", function(hooks) {

--- a/tests/integration/components/paginated-table/head/component-test.js
+++ b/tests/integration/components/paginated-table/head/component-test.js
@@ -1,6 +1,6 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import { module, test } from "qunit";
 
 module("Integration | Component | paginated table/head", function(hooks) {

--- a/tests/integration/components/pagination-limit/component-test.js
+++ b/tests/integration/components/pagination-limit/component-test.js
@@ -1,6 +1,6 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { click, render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import { module, test } from "qunit";
 
 module("Integration | Component | pagination limit", function(hooks) {

--- a/tests/integration/components/power-select/component-test.js
+++ b/tests/integration/components/power-select/component-test.js
@@ -1,10 +1,10 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { triggerKeyEvent, render } from "@ember/test-helpers";
 import {
   typeInSearch,
   clickTrigger
 } from "ember-power-select/test-support/helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import { module, test } from "qunit";
 
 const OPTIONS = [

--- a/tests/integration/components/progress-bar/component-test.js
+++ b/tests/integration/components/progress-bar/component-test.js
@@ -1,6 +1,6 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { find, render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import { module, test } from "qunit";
 
 module("Integration | Component | progress bar", function(hooks) {

--- a/tests/integration/components/progress-tooltip/component-test.js
+++ b/tests/integration/components/progress-tooltip/component-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from "@ember/object";
 import { render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import moment from "moment";
 import { module, skip, test } from "qunit";
 import { startMirage } from "timed/initializers/ember-cli-mirage";

--- a/tests/integration/components/record-button/component-test.js
+++ b/tests/integration/components/record-button/component-test.js
@@ -1,6 +1,6 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { click, render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import { module, test } from "qunit";
 
 module("Integration | Component | record button", function(hooks) {

--- a/tests/integration/components/report-review-warning/component-test.js
+++ b/tests/integration/components/report-review-warning/component-test.js
@@ -1,6 +1,6 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import { module, test } from "qunit";
 
 module("Integration | Component | report review warning", function(hooks) {

--- a/tests/integration/components/report-row/component-test.js
+++ b/tests/integration/components/report-row/component-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from "@ember/object";
 import { click, render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import { module, test } from "qunit";
 import { startMirage } from "timed/initializers/ember-cli-mirage";
 

--- a/tests/integration/components/sort-header/component-test.js
+++ b/tests/integration/components/sort-header/component-test.js
@@ -1,6 +1,6 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { click, render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import { module, test } from "qunit";
 
 module("Integration | Component | sort header", function(hooks) {

--- a/tests/integration/components/statistic-list/bar/component-test.js
+++ b/tests/integration/components/statistic-list/bar/component-test.js
@@ -1,6 +1,6 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import { module, test } from "qunit";
 
 module("Integration | Component | statistic list/bar", function(hooks) {

--- a/tests/integration/components/statistic-list/column/component-test.js
+++ b/tests/integration/components/statistic-list/column/component-test.js
@@ -1,6 +1,6 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import { module, test } from "qunit";
 
 module("Integration | Component | statistic list/column", function(hooks) {

--- a/tests/integration/components/statistic-list/component-test.js
+++ b/tests/integration/components/statistic-list/component-test.js
@@ -1,6 +1,6 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import { module, test } from "qunit";
 
 module("Integration | Component | statistic list", function(hooks) {

--- a/tests/integration/components/sy-calendar/component-test.js
+++ b/tests/integration/components/sy-calendar/component-test.js
@@ -1,6 +1,6 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { fillIn, render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import moment from "moment";
 import { module, test } from "qunit";
 

--- a/tests/integration/components/sy-checkbox/component-test.js
+++ b/tests/integration/components/sy-checkbox/component-test.js
@@ -1,6 +1,6 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { click, find, render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import { module, test } from "qunit";
 
 module("Integration | Component | sy checkbox", function(hooks) {

--- a/tests/integration/components/sy-checkmark/component-test.js
+++ b/tests/integration/components/sy-checkmark/component-test.js
@@ -1,6 +1,6 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import { module, test } from "qunit";
 
 module("Integration | Component | sy checkmark", function(hooks) {

--- a/tests/integration/components/sy-datepicker-btn/component-test.js
+++ b/tests/integration/components/sy-datepicker-btn/component-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { find, render } from "@ember/test-helpers";
 import { clickTrigger } from "ember-basic-dropdown/test-support/helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import moment from "moment";
 import { module, test } from "qunit";
 

--- a/tests/integration/components/sy-datepicker/component-test.js
+++ b/tests/integration/components/sy-datepicker/component-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { find, triggerEvent, click, render } from "@ember/test-helpers";
 import { clickTrigger } from "ember-basic-dropdown/test-support/helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import moment from "moment";
 import { module, test } from "qunit";
 

--- a/tests/integration/components/sy-durationpicker-day/component-test.js
+++ b/tests/integration/components/sy-durationpicker-day/component-test.js
@@ -1,6 +1,6 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import { module, test } from "qunit";
 
 module("Integration | Component | sy durationpicker day", function(hooks) {

--- a/tests/integration/components/sy-durationpicker/component-test.js
+++ b/tests/integration/components/sy-durationpicker/component-test.js
@@ -1,3 +1,4 @@
+import { hbs } from 'ember-cli-htmlbars';
 import {
   fillIn,
   blur,
@@ -6,7 +7,6 @@ import {
   settled
 } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import moment from "moment";
 import { module, test } from "qunit";
 import formatDuration from "timed/utils/format-duration";

--- a/tests/integration/components/sy-modal-target/component-test.js
+++ b/tests/integration/components/sy-modal-target/component-test.js
@@ -1,6 +1,6 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import { module, test } from "qunit";
 
 module("Integration | Component | sy modal target", function(hooks) {

--- a/tests/integration/components/sy-modal/body/component-test.js
+++ b/tests/integration/components/sy-modal/body/component-test.js
@@ -1,6 +1,6 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import { module, test } from "qunit";
 
 module("Integration | Component | sy modal/body", function(hooks) {

--- a/tests/integration/components/sy-modal/component-test.js
+++ b/tests/integration/components/sy-modal/component-test.js
@@ -1,6 +1,6 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { click, render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import { module, test } from "qunit";
 
 module("Integration | Component | sy modal", function(hooks) {

--- a/tests/integration/components/sy-modal/footer/component-test.js
+++ b/tests/integration/components/sy-modal/footer/component-test.js
@@ -1,6 +1,6 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import { module, test } from "qunit";
 
 module("Integration | Component | sy modal/footer", function(hooks) {

--- a/tests/integration/components/sy-modal/header/component-test.js
+++ b/tests/integration/components/sy-modal/header/component-test.js
@@ -1,6 +1,6 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { click, render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import { module, test } from "qunit";
 
 module("Integration | Component | sy modal/header", function(hooks) {

--- a/tests/integration/components/sy-modal/overlay/component-test.js
+++ b/tests/integration/components/sy-modal/overlay/component-test.js
@@ -1,6 +1,6 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { click, render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import { module, test } from "qunit";
 
 module("Integration | Component | sy modal/overlay", function(hooks) {

--- a/tests/integration/components/sy-timepicker/component-test.js
+++ b/tests/integration/components/sy-timepicker/component-test.js
@@ -1,3 +1,4 @@
+import { hbs } from 'ember-cli-htmlbars';
 import {
   fillIn,
   blur,
@@ -6,7 +7,6 @@ import {
   settled
 } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import moment from "moment";
 import { module, test } from "qunit";
 

--- a/tests/integration/components/sy-topnav/component-test.js
+++ b/tests/integration/components/sy-topnav/component-test.js
@@ -1,6 +1,6 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import { module, test } from "qunit";
 
 module("Integration | Component | sy topnav", function(hooks) {

--- a/tests/integration/components/task-selection/component-test.js
+++ b/tests/integration/components/task-selection/component-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from "@ember/object";
 import { click, render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import { module, test } from "qunit";
 import { startMirage } from "timed/initializers/ember-cli-mirage";
 

--- a/tests/integration/components/timed-clock/component-test.js
+++ b/tests/integration/components/timed-clock/component-test.js
@@ -1,6 +1,6 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import { module, test } from "qunit";
 
 module("Integration | Component | timed clock", function(hooks) {

--- a/tests/integration/components/tracking-bar/component-test.js
+++ b/tests/integration/components/tracking-bar/component-test.js
@@ -1,8 +1,8 @@
+import { hbs } from 'ember-cli-htmlbars';
 import Service from "@ember/service";
 import { render } from "@ember/test-helpers";
 import { task } from "ember-concurrency";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import { module, test } from "qunit";
 
 export const trackingStub = Service.extend({

--- a/tests/integration/components/user-selection/component-test.js
+++ b/tests/integration/components/user-selection/component-test.js
@@ -1,7 +1,7 @@
+import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from "@ember/object";
 import { find, render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import { module, test } from "qunit";
 import { startMirage } from "timed/initializers/ember-cli-mirage";
 

--- a/tests/integration/components/weekly-overview-benchmark/component-test.js
+++ b/tests/integration/components/weekly-overview-benchmark/component-test.js
@@ -1,6 +1,6 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { find, render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import { module, test } from "qunit";
 
 module("Integration | Component | weekly overview benchmark", function(hooks) {

--- a/tests/integration/components/weekly-overview-day/component-test.js
+++ b/tests/integration/components/weekly-overview-day/component-test.js
@@ -1,6 +1,6 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { click, find, render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import moment from "moment";
 import { module, test } from "qunit";
 

--- a/tests/integration/components/weekly-overview/component-test.js
+++ b/tests/integration/components/weekly-overview/component-test.js
@@ -1,6 +1,6 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import moment from "moment";
 import { module, test } from "qunit";
 

--- a/tests/integration/components/welcome-modal/component-test.js
+++ b/tests/integration/components/welcome-modal/component-test.js
@@ -1,6 +1,6 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import { module, test } from "qunit";
 
 module("Integration | Component | welcome modal", function(hooks) {

--- a/tests/integration/components/worktime-balance-chart/component-test.js
+++ b/tests/integration/components/worktime-balance-chart/component-test.js
@@ -1,6 +1,6 @@
+import { hbs } from 'ember-cli-htmlbars';
 import { render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
-import hbs from "htmlbars-inline-precompile";
 import { module, test } from "qunit";
 
 module("Integration | Component | worktime balance chart", function(hooks) {


### PR DESCRIPTION
## Contents:
* a689002 refactor(htmlbars-inline-precompile-codemod): change imports
* 2733767 refactor(es5-getter-ember-codemod): no ember.get anymore
* 7fd1441 refactor(ember-data-codemod): run codemod


The contents of this PR start at 7fd1441
Commits before belong to #714

---
## Info 
> 5th PR of [this series](https://github.com/adfinis/timed-frontend/pulls/710) #710.
> **Only merge when #714 is merged and this PR got rebased!**

---