### PR TITLE
refactor: date and time pickers

### DIFF
--- a/app/analysis/edit/template.hbs
+++ b/app/analysis/edit/template.hbs
@@ -9,7 +9,9 @@
       {{else}}
         <h1 class="text-center">
           {{#unless (eq this.intersection.lastSuccessful.value.meta.count 1)}}
-            Bulk edit {{this.intersection.lastSuccessful.value.meta.count}} reports
+            Bulk edit
+            {{this.intersection.lastSuccessful.value.meta.count}}
+            reports
           {{else}}
             Edit report
           {{/unless}}
@@ -23,25 +25,43 @@
                 as |f|
               >
                 <TaskSelection
-                  @on-set-customer={{action (queue (action (mut f.model.customer)) (action 'validate' f.model))}}
-                  @on-set-project={{action (queue (action (mut f.model.project)) (action 'validate' f.model))}}
-                  @on-set-task={{action (queue (action (mut f.model.task)) (action 'validate' f.model))}}
+                  @on-set-customer={{action
+                    (queue
+                      (action (mut f.model.customer))
+                      (action "validate" f.model)
+                    )
+                  }}
+                  @on-set-project={{action
+                    (queue
+                      (action (mut f.model.project)) (action "validate" f.model)
+                    )
+                  }}
+                  @on-set-task={{action
+                    (queue
+                      (action (mut f.model.task)) (action "validate" f.model)
+                    )
+                  }}
                   @initial={{hash
                     customer=this._customer
                     project=this._project
                     task=this._task
                   }}
-                  @disabled={{and this.isAccountant (not this.hasSelectedOwnReports)}}
+                  @disabled={{and
+                    this.isAccountant
+                    (not this.hasSelectedOwnReports)
+                  }}
                   as |t|
                 >
-                  <f.input @name='task' as |fi|>
+                  <f.input @name="task" as |fi|>
                     <div class="form-group" data-test-customer>
                       <label>
                         Customer
                         {{#unless model.customer}}
                           <NotIdenticalWarning />
                         {{/unless}}
-                        {{#unless (eq f.model.change.customer.id model.customer.id)}}
+                        {{#unless
+                          (eq f.model.change.customer.id model.customer.id)
+                        }}
                           <ChangedWarning />
                         {{/unless}}
                       </label>
@@ -53,7 +73,9 @@
                         {{#unless model.project}}
                           <NotIdenticalWarning />
                         {{/unless}}
-                        {{#unless (eq f.model.change.project.id model.project.id)}}
+                        {{#unless
+                          (eq f.model.change.project.id model.project.id)
+                        }}
                           <ChangedWarning />
                         {{/unless}}
                       </label>
@@ -73,11 +95,7 @@
                     </div>
                   </f.input>
 
-                  <f.input
-                    data-test-comment
-                    @name='comment'
-                    as |fi|
-                  >
+                  <f.input data-test-comment @name="comment" as |fi|>
                     <label>
                       Comment
                       {{#if (eq model.comment null)}}
@@ -91,24 +109,26 @@
                       type="text"
                       placeholder="Enter comment..."
                       class="form-control comment-field"
-                      onchange={{action fi.update value='target.value'}}
+                      onchange={{action fi.update value="target.value"}}
                       value={{fi.value}}
-                      disabled={{and this.isAccountant (not this.hasSelectedOwnReports)}}
-                    >
+                      disabled={{and
+                        this.isAccountant
+                        (not this.hasSelectedOwnReports)
+                      }}
+                    />
                     {{#if model.task.project.customerVisible}}
                       <CustomerVisibleIcon class="customer-visible-icon" />
                     {{/if}}
                   </f.input>
 
-                  <f.input
-                    data-test-not-billable
-                    @name='notBillable'
-                    as |fi|
-                  >
+                  <f.input data-test-not-billable @name="notBillable" as |fi|>
                     <SyCheckbox
                       @checked={{fi.value}}
-                      @on-change={{fi.update}}
-                      @disabled={{and this.isAccountant (not this.hasSelectedOwnReports)}}
+                      @onChange={{fi.update}}
+                      @disabled={{and
+                        this.isAccountant
+                        (not this.hasSelectedOwnReports)
+                      }}
                     >
                       Not billable
                       {{#if (eq model.notBillable null)}}
@@ -120,15 +140,14 @@
                     </SyCheckbox>
                   </f.input>
 
-                  <f.input
-                    data-test-review
-                    @name='review'
-                    as |fi|
-                  >
+                  <f.input data-test-review @name="review" as |fi|>
                     <SyCheckbox
                       @checked={{fi.value}}
-                      @on-change={{fi.update}}
-                      @disabled={{and this.isAccountant (not this.hasSelectedOwnReports)}}
+                      @onChange={{fi.update}}
+                      @disabled={{and
+                        this.isAccountant
+                        (not this.hasSelectedOwnReports)
+                      }}
                     >
                       Needs Review
                       {{#if (eq model.review null)}}
@@ -140,15 +159,14 @@
                     </SyCheckbox>
                   </f.input>
 
-                  <f.input
-                    data-test-billed
-                    @name='billed'
-                    as |fi|
-                  >
+                  <f.input data-test-billed @name="billed" as |fi|>
                     <SyCheckbox
                       @checked={{fi.value}}
-                      @on-change={{fi.update}}
-                      @title={{not this.canBill "You do not have appropriate roles for this action."}}
+                      @onChange={{fi.update}}
+                      @title={{not
+                        this.canBill
+                        "You do not have appropriate roles for this action."
+                      }}
                       @disabled={{not this.canBill}}
                     >
                       Billed
@@ -161,14 +179,10 @@
                     </SyCheckbox>
                   </f.input>
 
-                  <f.input
-                    data-test-verified
-                    @name='verified'
-                    as |fi|
-                  >
+                  <f.input data-test-verified @name="verified" as |fi|>
                     <SyCheckbox
                       @checked={{fi.value}}
-                      @on-change={{fi.update}}
+                      @onChange={{fi.update}}
                       @title={{this.toolTipText}}
                       @disabled={{or (not this.canVerify) this.needsReview}}
                     >
@@ -183,8 +197,18 @@
                   </f.input>
 
                   <div class="text-right">
-                    <button data-test-cancel type="button" class="btn" {{action 'cancel'}}>Cancel</button>
-                    <button data-test-reset type="button" class="btn" {{action (queue t.reset (action 'reset' f.model))}}>Reset</button>
+                    <button
+                      data-test-cancel
+                      type="button"
+                      class="btn"
+                      {{action "cancel"}}
+                    >Cancel</button>
+                    <button
+                      data-test-reset
+                      type="button"
+                      class="btn"
+                      {{action (queue t.reset (action "reset" f.model))}}
+                    >Reset</button>
                     <f.submit />
                   </div>
                 </TaskSelection>

--- a/app/components/report-row/component.js
+++ b/app/components/report-row/component.js
@@ -5,11 +5,8 @@
  */
 
 import { action } from "@ember/object";
-import { later } from "@ember/runloop";
 import { inject as service } from "@ember/service";
 import Component from "@glimmer/component";
-import Changeset from "ember-changeset";
-import lookupValidator from "ember-changeset-validations";
 import ReportValidations from "timed/validations/report";
 
 /**
@@ -22,6 +19,8 @@ import ReportValidations from "timed/validations/report";
 export default class ReportRowComponent extends Component {
   @service abilities;
 
+  ReportValidations = ReportValidations;
+
   get editable() {
     return this.abilities.can("edit report", this.args.report);
   }
@@ -33,34 +32,14 @@ export default class ReportRowComponent extends Component {
   }
 
   /**
-   * The changeset to edit
-   *
-   * @property {EmberChangeset.Changeset} changeset
-   * @public
-   */
-  get changeset() {
-    const c = new Changeset(
-      this.args.report,
-      lookupValidator(ReportValidations),
-      ReportValidations
-    );
-
-    later(() => {
-      c.validate();
-    });
-
-    return c;
-  }
-
-  /**
    * Save the row
    *
    * @method save
    * @public
    */
   @action
-  save() {
-    this.args.onSave(this.changeset);
+  save(changeset) {
+    this.args.onSave(changeset);
   }
   /**
    * Delete the row

--- a/app/components/report-row/template.hbs
+++ b/app/components/report-row/template.hbs
@@ -26,7 +26,7 @@
       name="comment"
       value={{this.changeset.comment}}
       disabled={{not this.editable}}
-      onchange={{action (mut this.changeset.comment) value="target.value"}}
+      {{on "change" (pick "target.value" (mut this.changeset.comment)}}
       data-test-report-comment
     />
     {{#if this.changeset.task.project.customerVisible}}

--- a/app/components/report-row/template.hbs
+++ b/app/components/report-row/template.hbs
@@ -34,29 +34,30 @@
     {{/if}}
   </div>
   <div class="form-list-cell form-group">
-    {{sy-durationpicker-day
+    <SyDurationpickerDay
       data-test-report-duration
-      disabled=(not this.editable)
-      value=this.changeset.duration
-      on-change=(action (mut this.changeset.duration))
-    }}</div>
-  <div class="form-list-cell form-group">
-    {{sy-checkbox
-      data-test-report-review
-      disabled=(not this.editable)
-      checked=this.changeset.review
-      on-change=(action (mut this.changeset.review))
-      label="Needs review"
-    }}
+      @disabled={{(not this.editable)}}
+      @value={{this.changeset.duration}}
+      @onChange={{fn (mut this.changeset.duration)}}
+    />
   </div>
   <div class="form-list-cell form-group">
-    {{sy-checkbox
+    <SyCheckbox
+      data-test-report-review
+      @disabled={{(not this.editable)}}
+      @checked={{this.changeset.review}}
+      @onChange={{fn (mut this.changeset.review)}}
+      @label="Needs review"
+    />
+  </div>
+  <div class="form-list-cell form-group">
+    <SyCheckbox
       data-test-report-not-billable
-      disabled=(not this.editable)
-      checked=this.changeset.notBillable
-      on-change=(action (mut this.changeset.notBillable))
-      label="Not billable"
-    }}
+      @disabled={{(not this.editable)}}
+      @checked={{this.changeset.notBillable}}
+      @onChange={{fn (mut this.changeset.notBillable)}}
+      @label="Not billable"
+    />
   </div>
   <div class="form-list-cell form-group">
     {{#if this.editable}}

--- a/app/components/report-row/template.hbs
+++ b/app/components/report-row/template.hbs
@@ -19,14 +19,16 @@
   </TaskSelection>
 
   <div class="form-list-cell form-group">
+    <label for="row-comment" hidden>Comment</label>
     <input
       type="text"
       class="form-control comment-field"
       placeholder="Comment"
       name="comment"
+      id="row-comment"
       value={{this.changeset.comment}}
       disabled={{not this.editable}}
-      {{on "change" (pick "target.value" (mut this.changeset.comment)}}
+      {{on "change" (pick "target.value" (mut this.changeset.comment))}}
       data-test-report-comment
     />
     {{#if this.changeset.task.project.customerVisible}}
@@ -66,7 +68,7 @@
         data-test-delete-report
         class="btn btn-danger"
         disabled={{this.report.verifiedBy.id}}
-        {{action "delete"}}
+        {{this.delete}}
       >{{fa-icon "trash"}}</button>
       <button
         type="submit"
@@ -76,7 +78,7 @@
           (not this.changeset.isDirty)
           (not this.changeset.isValid)
         }}
-        {{action "save"}}
+        {{this.save}}
       >{{fa-icon "save"}}</button>
     {{/if}}
   </div>

--- a/app/components/report-row/template.hbs
+++ b/app/components/report-row/template.hbs
@@ -2,6 +2,7 @@
   <TaskSelection
     @disabled={{not this.editable}}
     @task={{this.changeset.task}}
+    @on-set-task={{fn (mut this.changeset.task)}}
     as |t|
   >
     <div
@@ -28,7 +29,7 @@
       id="row-comment"
       value={{this.changeset.comment}}
       disabled={{not this.editable}}
-      {{on "change" (pick "target.value" (mut this.changeset.comment))}}
+      {{on "change" (pick "target.value" (fn (mut this.changeset.comment)))}}
       data-test-report-comment
     />
     {{#if this.changeset.task.project.customerVisible}}
@@ -68,7 +69,7 @@
         data-test-delete-report
         class="btn btn-danger"
         disabled={{this.report.verifiedBy.id}}
-        {{this.delete}}
+        {{on "click" this.delete}}
       >{{fa-icon "trash"}}</button>
       <button
         type="submit"
@@ -78,7 +79,7 @@
           (not this.changeset.isDirty)
           (not this.changeset.isValid)
         }}
-        {{this.save}}
+        {{on "click" (prevent-default this.save)}}
       >{{fa-icon "save"}}</button>
     {{/if}}
   </div>

--- a/app/components/report-row/template.hbs
+++ b/app/components/report-row/template.hbs
@@ -1,86 +1,82 @@
-<form class="form-list-row" title={{this.title}}>
-  <TaskSelection
-    @disabled={{not this.editable}}
-    @task={{this.changeset.task}}
-    @on-set-task={{fn (mut this.changeset.task)}}
-    as |t|
-  >
-    <div
-      class="form-list-cell form-group
-        {{if this.changeset.error.task 'has-error'}}"
-    >{{t.customer}}</div>
-    <div
-      class="form-list-cell form-group
-        {{if this.changeset.error.task 'has-error'}}"
-    >{{t.project}}</div>
-    <div
-      class="form-list-cell form-group
-        {{if this.changeset.error.task 'has-error'}}"
-    >{{t.task}}</div>
-  </TaskSelection>
+{{#let (changeset @report this.ReportValidations) as |cs|}}
+  <form class="form-list-row" title={{this.title}}>
+    <TaskSelection
+      @disabled={{not this.editable}}
+      @task={{cs.task}}
+      @on-set-task={{fn (mut cs.task)}}
+      as |t|
+    >
+      <div
+        class="form-list-cell form-group {{if cs.error.task 'has-error'}}"
+      >{{t.customer}}</div>
+      <div
+        class="form-list-cell form-group {{if cs.error.task 'has-error'}}"
+      >{{t.project}}</div>
+      <div
+        class="form-list-cell form-group {{if cs.error.task 'has-error'}}"
+      >{{t.task}}</div>
+    </TaskSelection>
 
-  <div class="form-list-cell form-group">
-    <label for="row-comment" hidden>Comment</label>
-    <input
-      type="text"
-      class="form-control comment-field"
-      placeholder="Comment"
-      name="comment"
-      id="row-comment"
-      value={{this.changeset.comment}}
-      disabled={{not this.editable}}
-      {{on "change" (pick "target.value" (fn (mut this.changeset.comment)))}}
-      data-test-report-comment
-    />
-    {{#if this.changeset.task.project.customerVisible}}
-      <CustomerVisibleIcon class="customer-visible-icon" />
-    {{/if}}
-  </div>
-  <div class="form-list-cell form-group">
-    <SyDurationpickerDay
-      data-test-report-duration
-      @disabled={{(not this.editable)}}
-      @value={{this.changeset.duration}}
-      @onChange={{fn (mut this.changeset.duration)}}
-    />
-  </div>
-  <div class="form-list-cell form-group">
-    <SyCheckbox
-      data-test-report-review
-      @disabled={{(not this.editable)}}
-      @checked={{this.changeset.review}}
-      @onChange={{fn (mut this.changeset.review)}}
-      @label="Needs review"
-    />
-  </div>
-  <div class="form-list-cell form-group">
-    <SyCheckbox
-      data-test-report-not-billable
-      @disabled={{(not this.editable)}}
-      @checked={{this.changeset.notBillable}}
-      @onChange={{fn (mut this.changeset.notBillable)}}
-      @label="Not billable"
-    />
-  </div>
-  <div class="form-list-cell form-group">
-    {{#if this.editable}}
-      <button
-        type="button"
-        data-test-delete-report
-        class="btn btn-danger"
-        disabled={{this.report.verifiedBy.id}}
-        {{on "click" this.delete}}
-      >{{fa-icon "trash"}}</button>
-      <button
-        type="submit"
-        data-test-save-report
-        class="btn btn-primary"
-        disabled={{or
-          (not this.changeset.isDirty)
-          (not this.changeset.isValid)
-        }}
-        {{on "click" (prevent-default this.save)}}
-      >{{fa-icon "save"}}</button>
-    {{/if}}
-  </div>
-</form>
+    <div class="form-list-cell form-group">
+      <label for="row-comment" hidden>Comment</label>
+      <input
+        type="text"
+        class="form-control comment-field"
+        placeholder="Comment"
+        name="comment"
+        id="row-comment"
+        value={{cs.comment}}
+        disabled={{not this.editable}}
+        {{on "change" (pick "target.value" (fn (mut cs.comment)))}}
+        data-test-report-comment
+      />
+      {{#if cs.task.project.customerVisible}}
+        <CustomerVisibleIcon class="customer-visible-icon" />
+      {{/if}}
+    </div>
+    <div class="form-list-cell form-group">
+      <SyDurationpickerDay
+        data-test-report-duration
+        @disabled={{(not this.editable)}}
+        @value={{cs.duration}}
+        @onChange={{fn (mut cs.duration)}}
+      />
+    </div>
+    <div class="form-list-cell form-group">
+      <SyCheckbox
+        data-test-report-review
+        @disabled={{(not this.editable)}}
+        @checked={{cs.review}}
+        @onChange={{fn (mut cs.review)}}
+        @label="Needs review"
+      />
+    </div>
+    <div class="form-list-cell form-group">
+      <SyCheckbox
+        data-test-report-not-billable
+        @disabled={{(not this.editable)}}
+        @checked={{cs.notBillable}}
+        @onChange={{fn (mut cs.notBillable)}}
+        @label="Not billable"
+      />
+    </div>
+    <div class="form-list-cell form-group">
+      {{#if this.editable}}
+        <button
+          type="button"
+          data-test-delete-report
+          class="btn btn-danger"
+          disabled={{this.report.verifiedBy.id}}
+          {{on "click" this.delete}}
+        >{{fa-icon "trash"}}</button>
+        <button
+          type="submit"
+          data-test-save-report
+          class="btn btn-primary"
+          disabled={{or (not cs.isDirty) (not cs.isValid)}}
+          {{on "click" (prevent-default (fn this.save cs))}}
+        >{{fa-icon "save"}}</button>
+      {{/if}}
+    </div>
+  </form>
+{{/let}}

--- a/app/components/sy-calendar/template.hbs
+++ b/app/components/sy-calendar/template.hbs
@@ -1,31 +1,45 @@
 <PowerCalendar
   ...attributes
+  class="sy-calendar"
   @onSelect={{@onSelect}}
   @selected={{@selected}}
   @center={{@center}}
-  @onCenterChange={{@onCenterChange}} as |calendar|
+  @onCenterChange={{@onCenterChange}}
+  as |calendar|
 >
   <calendar.Nav>
     <span class="nav-select-month">
-      {{#let (moment-format calendar.center 'MMMM') as |currentMonth|}}
+      {{#let (moment-format calendar.center "MMMM") as |currentMonth|}}
         {{currentMonth}}
-        <select aria-label="Month" {{ on "change" (fn this.changeCenter "month" calendar) }}>
+        <select
+          aria-label="Month"
+          {{on "change" (fn this.changeCenter "month" calendar)}}
+        >
           {{#each this.months as |month|}}
-            <option value={{month}} selected={{eq month currentMonth}}>{{month}}</option>
+            <option
+              value={{month}}
+              selected={{eq month currentMonth}}
+            >{{month}}</option>
           {{/each}}
         </select>
       {{/let}}
     </span>
     <span class="nav-select-year">
-      {{#let (moment-format calendar.center 'YYYY') as |currentYear|}}
+      {{#let (moment-format calendar.center "YYYY") as |currentYear|}}
         {{currentYear}}
-        <select aria-label="Year" {{on "change" (fn this.changeCenter "year" calendar)}}>
+        <select
+          aria-label="Year"
+          {{on "change" (fn this.changeCenter "year" calendar)}}
+        >
           {{#each this.years as |year|}}
-            <option value={{year}} selected={{eq year currentYear}}>{{year}}</option>
+            <option
+              value={{year}}
+              selected={{eq year currentYear}}
+            >{{year}}</option>
           {{/each}}
         </select>
       {{/let}}
     </span>
   </calendar.Nav>
-  <calendar.Days/>
+  <calendar.Days />
 </PowerCalendar>

--- a/app/components/sy-checkbox/component.js
+++ b/app/components/sy-checkbox/component.js
@@ -3,11 +3,9 @@
  * @submodule timed-components
  * @public
  */
-import { classNames } from "@ember-decorators/component";
-import Component from "@ember/component";
-import { computed } from "@ember/object";
-import { scheduleOnce } from "@ember/runloop";
-import classic from "ember-classic-decorator";
+import { action } from "@ember/object";
+import { guidFor } from "@ember/object/internals";
+import Component from "@glimmer/component";
 
 /**
  * Component for an adcssy styled checkbox
@@ -16,55 +14,21 @@ import classic from "ember-classic-decorator";
  * @extends Ember.Component
  * @public
  */
-@classic
-@classNames("checkbox")
 export default class SyCheckbox extends Component {
-  @computed("elementId")
+  constructor(...args) {
+    super(...args);
+
+    this._checkboxElementId = guidFor(this);
+  }
+
   get checkboxElementId() {
-    return `${this.elementId}-checkbox`;
+    return this._checkboxElementId;
   }
 
-  didReceiveAttrs() {
-    scheduleOnce("afterRender", this, this.deferredWork);
-  }
-
-  deferredWork() {
-    if (this.checked === null) {
-      const cb = this.element.querySelector(`#${this.checkboxElementId}`);
-
-      cb.indeterminate = true;
+  @action
+  handleCheckBox(element) {
+    if (this.args.checked === null) {
+      element.indeterminate = true;
     }
   }
-
-  /**
-   * Action to call if the checked state has changed
-   *
-   * @method on-change
-   * @public
-   */
-  "on-change"() {}
-
-  /**
-   * The label of the checkbox
-   *
-   * @property {String} label
-   * @public
-   */
-  label = "";
-
-  /**
-   * Whether the checkbox is checked
-   *
-   * @property {Boolean} checked
-   * @public
-   */
-  checked = false;
-
-  /**
-   * Whether the checkbox is disabled
-   *
-   * @property {Boolean} disabled
-   * @public
-   */
-  disabled = false;
 }

--- a/app/components/sy-checkbox/template.hbs
+++ b/app/components/sy-checkbox/template.hbs
@@ -1,8 +1,21 @@
-<input
-  type="checkbox"
-  id={{this.checkboxElementId}}
-  checked={{this.checked}}
-  disabled={{this.disabled}}
-  onchange={{action this.on-change value='target.checked'}}
->
-<label for={{this.checkboxElementId}} title={{this.title}}>{{#if has-block}}{{~yield~}}{{else}}{{#if this.label}}{{~label~}}{{else}}&nbsp;{{/if}}{{/if}}</label>
+<div class="checkbox">
+  <input
+    type="checkbox"
+    id={{this.checkboxElementId}}
+    checked={{@checked}}
+    disabled={{@disabled}}
+    {{on "change" (pick "target.checked" (optional @onChange))}}
+    {{did-insert this.handleCheckBox}}
+  />
+  <label for={{this.checkboxElementId}} title={{@title}}>
+    {{#if (has-block)}}
+      {{yield}}
+    {{else}}
+      {{#if @label}}
+        {{@label}}
+      {{else}}
+        &nbsp;
+      {{/if}}
+    {{/if}}
+  </label>
+</div>

--- a/app/components/sy-checkmark/component.js
+++ b/app/components/sy-checkmark/component.js
@@ -1,12 +1,7 @@
-import { tracked } from "@glimmer/tracking";
-import classic from "ember-classic-decorator";
-import FaIconComponent from "ember-font-awesome/components/fa-icon";
+import Component from "@glimmer/component";
 
-@classic
-export default class SyCheckmark extends FaIconComponent {
-  @tracked checked = false;
-
+export default class SyCheckmark extends Component {
   get icon() {
-    return this.checked ? "check-square-o" : "square-o";
+    return this.args.checked ? "check-square-o" : "square-o";
   }
 }

--- a/app/components/sy-checkmark/template.hbs
+++ b/app/components/sy-checkmark/template.hbs
@@ -1,0 +1,1 @@
+{{fa-icon this.icon}}

--- a/app/components/sy-durationpicker-day/component.js
+++ b/app/components/sy-durationpicker-day/component.js
@@ -1,14 +1,14 @@
 import moment from "moment";
 import SyDurationpickerComponent from "timed/components/sy-durationpicker/component";
 
-export default SyDurationpickerComponent.extend({
-  maxlength: 5,
+export default class SyDurationpickerDayComponent extends SyDurationpickerComponent {
+  maxlength = 5;
 
-  max: moment.duration({ h: 24, m: 0 }),
+  max = moment.duration({ h: 24, m: 0 });
 
-  min: moment.duration({ h: 0, m: 0 }),
+  min = moment.duration({ h: 0, m: 0 });
 
   sanitize(value) {
     return value.replace(/[^\d:]/, "");
   }
-});
+}

--- a/app/components/sy-durationpicker-day/template.hbs
+++ b/app/components/sy-durationpicker-day/template.hbs
@@ -1,0 +1,11 @@
+<input
+  type="text"
+  class="form-control"
+  pattern={{this.pattern}}
+  value={{this.displayValue}}
+  maxlength={{this.maxlength}}
+  placeholder={{this.placeholder}}
+  autocomplete="off"
+  {{on "keydown" this.handleKeyPress}}
+  {{on "focusout" (optiona @onFocusOut)}}
+/>

--- a/app/components/sy-durationpicker-day/template.hbs
+++ b/app/components/sy-durationpicker-day/template.hbs
@@ -1,4 +1,5 @@
 <input
+  aria-label="day picker"
   type="text"
   class="form-control"
   pattern={{this.pattern}}
@@ -7,5 +8,5 @@
   placeholder={{this.placeholder}}
   autocomplete="off"
   {{on "keydown" this.handleKeyPress}}
-  {{on "focusout" (optiona @onFocusOut)}}
+  {{on "focusout" (optional @onFocusOut)}}
 />

--- a/app/components/sy-durationpicker/component.js
+++ b/app/components/sy-durationpicker/component.js
@@ -1,13 +1,15 @@
-import { tracked } from '@glimmer/tracking';
-import classic from "ember-classic-decorator";
-import { computed } from "@ember/object";
+/**
+ * @module timed
+ * @submodule timed-components
+ * @public
+ */
+import { action } from "@ember/object";
 import { padStart } from "ember-pad/utils/pad";
 import moment from "moment";
 import SyTimepickerComponent from "timed/components/sy-timepicker/component";
 import formatDuration from "timed/utils/format-duration";
 
 const { MIN_SAFE_INTEGER, MAX_SAFE_INTEGER } = Number;
-
 const { abs } = Math;
 
 /**
@@ -17,10 +19,9 @@ const { abs } = Math;
  * @extends Ember.Component
  * @public
  */
-@classic
 export default class SyDurationpicker extends SyTimepickerComponent {
   name = "duration";
-  @tracked min = MIN_SAFE_INTEGER;
+  min = MIN_SAFE_INTEGER;
   max = MAX_SAFE_INTEGER;
   maxlength = null;
 
@@ -36,7 +37,7 @@ export default class SyDurationpicker extends SyTimepickerComponent {
    * @property {Number} precision
    * @public
    */
-  @tracked precision = 15;
+  precision = 15;
 
   /**
    * The regex for the input
@@ -48,9 +49,9 @@ export default class SyDurationpicker extends SyTimepickerComponent {
     const count = 60 / this.precision;
     const minutes = Array.from({ length: count }, (v, i) => (60 / count) * i);
 
-    return `${
-      this.min < 0 ? "-?" : ""
-    }\\d+:(${minutes.map(m => padStart(m, 2)).join("|")})`;
+    return `${this.min < 0 ? "-?" : ""}\\d+:(${minutes
+      .map((m) => padStart(m, 2))
+      .join("|")})`;
   }
 
   change({ target: { validity, value } }) {
@@ -59,7 +60,7 @@ export default class SyDurationpicker extends SyTimepickerComponent {
 
       const [h = NaN, m = NaN] = this.sanitize(value)
         .split(":")
-        .map(n => abs(parseInt(n)) * (negative ? -1 : 1));
+        .map((n) => abs(parseInt(n)) * (negative ? -1 : 1));
 
       this._change([h, m].some(isNaN) ? null : this._set(h, m));
     }
@@ -73,9 +74,10 @@ export default class SyDurationpicker extends SyTimepickerComponent {
    * @property {String} displayValue
    * @public
    */
-  @computed("value")
   get displayValue() {
-    return this.value ? formatDuration(this.value, false) : "";
+    return this.args.value
+      ? formatDuration(this.args.value.content ?? this.args.value, false)
+      : "";
   }
 
   /**
@@ -101,6 +103,11 @@ export default class SyDurationpicker extends SyTimepickerComponent {
    * @private
    */
   _add(h, m) {
-    return moment.duration(this.value).add({ h, m });
+    return moment.duration(this.args.value).add({ h, m });
+  }
+
+  @action
+  handleKeyPress(event) {
+    super.keyDown(event);
   }
 }

--- a/app/components/sy-durationpicker/component.js
+++ b/app/components/sy-durationpicker/component.js
@@ -20,14 +20,7 @@ const { abs } = Math;
  * @public
  */
 export default class SyDurationpicker extends SyTimepickerComponent {
-  name = "duration";
-  min = MIN_SAFE_INTEGER;
-  max = MAX_SAFE_INTEGER;
   maxlength = null;
-
-  sanitize(value) {
-    return value.replace(/[^\d:-]/, "");
-  }
 
   /**
    * The precision of the time
@@ -38,6 +31,14 @@ export default class SyDurationpicker extends SyTimepickerComponent {
    * @public
    */
   precision = 15;
+
+  get min() {
+    return this.args.min ?? MIN_SAFE_INTEGER;
+  }
+
+  get max() {
+    return this.args.max ?? MAX_SAFE_INTEGER;
+  }
 
   /**
    * The regex for the input
@@ -52,18 +53,6 @@ export default class SyDurationpicker extends SyTimepickerComponent {
     return `${this.min < 0 ? "-?" : ""}\\d+:(${minutes
       .map((m) => padStart(m, 2))
       .join("|")})`;
-  }
-
-  change({ target: { validity, value } }) {
-    if (validity.valid) {
-      const negative = /^-/.test(value);
-
-      const [h = NaN, m = NaN] = this.sanitize(value)
-        .split(":")
-        .map((n) => abs(parseInt(n)) * (negative ? -1 : 1));
-
-      this._change([h, m].some(isNaN) ? null : this._set(h, m));
-    }
   }
 
   /**
@@ -104,6 +93,23 @@ export default class SyDurationpicker extends SyTimepickerComponent {
    */
   _add(h, m) {
     return moment.duration(this.args.value).add({ h, m });
+  }
+
+  _isValid(duration) {
+    return duration < this.max && duration > this.min;
+  }
+
+  @action
+  change({ target: { validity, value } }) {
+    if (validity.valid) {
+      const negative = /^-/.test(value);
+
+      const [h = NaN, m = NaN] = this.sanitize(value)
+        .split(":")
+        .map((n) => abs(parseInt(n)) * (negative ? -1 : 1));
+
+      this._change([h, m].some(isNaN) ? null : this._set(h, m));
+    }
   }
 
   @action

--- a/app/components/sy-durationpicker/component.js
+++ b/app/components/sy-durationpicker/component.js
@@ -92,7 +92,7 @@ export default class SyDurationpicker extends SyTimepickerComponent {
    * @private
    */
   _add(h, m) {
-    return moment.duration(this.args.value).add({ h, m });
+    return moment.duration(this.value).add({ h, m });
   }
 
   _isValid(duration) {

--- a/app/components/sy-durationpicker/template.hbs
+++ b/app/components/sy-durationpicker/template.hbs
@@ -1,0 +1,11 @@
+<input
+  type="text"
+  class="form-control"
+  pattern={{this.pattern}}
+  value={{this.displayValue}}
+  maxlength={{this.maxlength}}
+  placeholder={{this.placeholder}}
+  autocomplete="off"
+  {{on "keydown" this.handleKeyPress}}
+  {{on "focusout" (optional @onFocusOut)}}
+/>

--- a/app/components/sy-durationpicker/template.hbs
+++ b/app/components/sy-durationpicker/template.hbs
@@ -1,4 +1,5 @@
 <input
+  aria-label="duration picker"
   type="text"
   class="form-control"
   pattern={{this.pattern}}
@@ -6,6 +7,7 @@
   maxlength={{this.maxlength}}
   placeholder={{this.placeholder}}
   autocomplete="off"
+  {{on "change" this.change}}
   {{on "keydown" this.handleKeyPress}}
   {{on "focusout" (optional @onFocusOut)}}
 />

--- a/app/components/sy-timepicker/component.js
+++ b/app/components/sy-timepicker/component.js
@@ -20,6 +20,9 @@ export default class SyTimepickerComponent extends Component {
     if (this.isProxiedDate(date)) {
       return date.unwrap();
     }
+    if (this.isProxiedDuration(date)) {
+      return moment.duration({ ...date.unwrap()._data });
+    }
     return date;
   }
 
@@ -27,7 +30,13 @@ export default class SyTimepickerComponent extends Component {
     return obj && obj.unwrap && obj.unwrap()._isAMomentObject;
   }
 
-  sanitize (value) {
+  isProxiedDuration(obj) {
+    return (
+      obj && obj.unwrap && obj.unwrap()._data && obj.unwrap()._milliseconds
+    );
+  }
+
+  sanitize(value) {
     return value.replace(/[^\d:]/, "");
   }
 
@@ -107,7 +116,6 @@ export default class SyTimepickerComponent extends Component {
    * @public
    */
   get displayValue() {
-
     return this.args.value && this.args.value.isValid()
       ? this.args.value.format("HH:mm")
       : "";

--- a/app/components/sy-timepicker/component.js
+++ b/app/components/sy-timepicker/component.js
@@ -27,7 +27,7 @@ export default class SyTimepickerComponent extends Component {
     return obj && obj.unwrap && obj.unwrap()._isAMomentObject;
   }
 
-  sanitize(value) {
+  sanitize (value) {
     return value.replace(/[^\d:]/, "");
   }
 
@@ -186,7 +186,10 @@ export default class SyTimepickerComponent extends Component {
    * @return {Boolean} Whether the value is valid
    * @private
    */
-  _isValid(value) {
+  _isValid(momentOrDuration) {
+    const value = momentOrDuration._isAMomentObject
+      ? momentOrDuration
+      : moment(momentOrDuration);
     return value.isBefore(moment(this.max)) && value.isAfter(moment(this.min));
   }
 

--- a/app/components/sy-timepicker/template.hbs
+++ b/app/components/sy-timepicker/template.hbs
@@ -1,4 +1,5 @@
 <input
+  aria-label="time picker"
   type="text"
   class="form-control"
   pattern={{this.pattern}}

--- a/app/components/sy-timepicker/template.hbs
+++ b/app/components/sy-timepicker/template.hbs
@@ -1,0 +1,12 @@
+<input
+  type="text"
+  class="form-control"
+  pattern={{this.pattern}}
+  value={{this.displayValue}}
+  maxlength={{this.maxlength}}
+  placeholder={{this.placeholder}}
+  autocomplete="off"
+  {{on "keydown" this.keyDown}}
+  {{on "change" this.change}}
+  {{on "focusout" (optional @onFocusOut)}}
+/>

--- a/app/components/task-selection/component.js
+++ b/app/components/task-selection/component.js
@@ -143,7 +143,7 @@ export default class TaskSelectionComponent extends Component {
   get customer() {
     // Without unwrapping of the proxy ember-power-select will stick to wrong reference after clearing
     return this.args.liveTracking
-      ? (this.tracking.activeCustomer?.content ?? this._customer)
+      ? this.tracking.activeCustomer?.content ?? this._customer
       : this._customer;
   }
 
@@ -159,7 +159,7 @@ export default class TaskSelectionComponent extends Component {
   get project() {
     // Without unwrapping of the proxy ember-power-select will stick to wrong reference after clearing
     return this.args.liveTracking
-      ? (this.tracking.activeProject?.content ?? this._project)
+      ? this.tracking.activeProject?.content ?? this._project
       : this._project;
   }
 
@@ -171,7 +171,7 @@ export default class TaskSelectionComponent extends Component {
    */
   get task() {
     return this.args.liveTracking
-      ? (this.tracking.activeTask?.content ?? this._task)
+      ? this.tracking.activeTask?.content ?? this._task
       : this._task;
   }
 
@@ -320,7 +320,7 @@ export default class TaskSelectionComponent extends Component {
     if (!options.preventAction && this._customer) {
       later(this, () => {
         (this.args["on-set-customer"] === undefined
-          ? () => { }
+          ? () => {}
           : this.args["on-set-customer"])(value);
       });
     }
@@ -349,7 +349,7 @@ export default class TaskSelectionComponent extends Component {
     if (!options.preventAction) {
       later(this, () => {
         (this.args["on-set-project"] === undefined
-          ? () => { }
+          ? () => {}
           : this.args["on-set-project"])(value);
       });
     }
@@ -370,7 +370,7 @@ export default class TaskSelectionComponent extends Component {
     if (!options.preventAction) {
       later(this, async () => {
         (this.args["on-set-task"] === undefined
-          ? () => { }
+          ? () => {}
           : this.args["on-set-task"])(value);
       });
     }

--- a/app/index/activities/controller.js
+++ b/app/index/activities/controller.js
@@ -224,7 +224,7 @@ export default class ActivitiesIndexController extends Controller {
             .then(report.save.bind(report));
         }, resolve());
 
-      await this.router.transitionTo("index.reports");
+      this.router.transitionTo("index.reports");
     } catch (e) {
       /* istanbul ignore next */
       this.notify.error("Error while generating reports");

--- a/app/index/activities/edit/controller.js
+++ b/app/index/activities/edit/controller.js
@@ -39,17 +39,14 @@ export default class IndexActivitiesEditController extends Controller {
    * @public
    */
   @action
-  validateChangeset(changeset) {
+  validateChangeset() {
     this.changeset.validate();
   }
 
   @action
-  toggle(prop) {
-    this.changeset[prop] = !!this.changeset[prop];
-  }
+  async save(e) {
+    e.preventDefault();
 
-  @action
-  async save() {
     /* istanbul ignore next */
     if (!this.saveEnabled) {
       /* UI prevents this, but could be executed by pressing enter */
@@ -61,7 +58,7 @@ export default class IndexActivitiesEditController extends Controller {
 
       this.notify.success("Activity was saved");
 
-      await this.router.transitionTo("index.activities");
+      this.router.transitionTo("index.activities");
     } catch (e) {
       console.error(e);
       /* istanbul ignore next */
@@ -92,7 +89,7 @@ export default class IndexActivitiesEditController extends Controller {
 
       this.notify.success("Activity was deleted");
 
-      await this.router.transitionTo("index.activities");
+      this.router.transitionTo("index.activities");
     } catch (e) {
       console.error(e);
       /* istanbul ignore next */

--- a/app/index/activities/edit/route.js
+++ b/app/index/activities/edit/route.js
@@ -4,7 +4,6 @@
  * @public
  */
 import Route from "@ember/routing/route";
-import { inject as service } from "@ember/service";
 import Changeset from "ember-changeset";
 import lookupValidator from "ember-changeset-validations";
 import RouteAutostartTourMixin from "timed/mixins/route-autostart-tour";
@@ -17,15 +16,9 @@ import ActivityValidator from "timed/validations/activity";
  * @extends Ember.Route
  * @public
  */
-export default Route.extend(RouteAutostartTourMixin, {
-  /**
-   * The notify service
-   *
-   * @property {EmberNotify.NotifyService} notify
-   * @public
-   */
-  notify: service("notify"),
-
+export default class IndexActivityEditController extends Route.extend(
+  RouteAutostartTourMixin
+) {
   /**
    * Model hook, fetch the activity to edit
    *
@@ -37,13 +30,13 @@ export default Route.extend(RouteAutostartTourMixin, {
    */
   model({ id }) {
     return this.store.findRecord("activity", id);
-  },
+  }
 
   afterModel(model) {
     if (model.get("transferred")) {
       this.transitionTo("index");
     }
-  },
+  }
 
   /**
    * Setup controller hook, generate a changeset from the model
@@ -54,78 +47,15 @@ export default Route.extend(RouteAutostartTourMixin, {
    * @public
    */
   setupController(controller, model, ...args) {
-    this._super(controller, model, ...args);
+    super.setupController(controller, model, ...args);
 
     const changeset = new Changeset(
       model,
       lookupValidator(ActivityValidator),
       ActivityValidator
     );
-
     changeset.validate();
 
     controller.setProperties({ changeset });
-  },
-
-  /**
-   * Actions for the route
-   *
-   * @property {Object} actions
-   * @public
-   */
-  actions: {
-    /**
-     * Save the activity
-     *
-     * @method save
-     * @public
-     */
-    async save() {
-      /* istanbul ignore next */
-      if (!this.get("controller.saveEnabled")) {
-        /* UI prevents this, but could be executed by pressing enter */
-        return;
-      }
-
-      try {
-        await this.get("controller.changeset").save();
-
-        this.notify.success("Activity was saved");
-
-        await this.transitionTo("index.activities");
-      } catch (e) {
-        /* istanbul ignore next */
-        this.notify.error("Error while saving the activity");
-      }
-    },
-
-    /**
-     * Delete the activity
-     *
-     * @method delete
-     * @public
-     */
-    async delete() {
-      /* istanbul ignore next */
-      if (this.get("currentModel.active")) {
-        // We can't test this because the UI already prevents this by disabling
-        // the save button..
-
-        this.notify.error("You can't delete an active activity");
-
-        return;
-      }
-
-      try {
-        await this.currentModel.destroyRecord();
-
-        this.notify.success("Activity was deleted");
-
-        await this.transitionTo("index.activities");
-      } catch (e) {
-        /* istanbul ignore next */
-        this.notify.error("Error while deleting the activity");
-      }
-    }
   }
-});
+}

--- a/app/index/activities/edit/template.hbs
+++ b/app/index/activities/edit/template.hbs
@@ -1,7 +1,12 @@
-<form data-test-activity-edit-form {{action 'save' on='submit'}}>
+<label hidden for="activity-edit-form">Edit activity</label>
+<form
+  id="activity-edit-form"
+  data-test-activity-edit-form
+  {{on "submit" this.save}}
+>
   <div class="card">
     <div class="card-header hidden-lg">
-      <LinkTo @route="index.activities">{{fa-icon 'chevron-left'}}</LinkTo>
+      <LinkTo @route="index.activities">{{fa-icon "chevron-left"}}</LinkTo>
     </div>
     <div class="card-block">
       <TaskSelection @task={{this.changeset.task}} as |t|>
@@ -9,65 +14,81 @@
         <div class="form-group">{{t.project}}</div>
         <div class="form-group">{{t.task}}</div>
       </TaskSelection>
+    </div>
+    <div class="card-footer text-right">
       <div class="form-group">
+        <label hidden for="comment">Comment</label>
         <input
           type="text"
           class="form-control comment-field"
           placeholder="Comment"
           name="comment"
+          id="comment"
           value={{this.changeset.comment}}
-          onchange={{action (mut this.changeset.comment) value='target.value'}}
-        >
-        {{#if this.changeset.task.project.customerVisible }}
+          {{on
+            "change"
+            (pick "target.value" (fn (mut this.changeset.comment)))
+          }}
+        />
+        {{#if this.changeset.task.project.customerVisible}}
           <CustomerVisibleIcon class="customer-visible-icon" />
         {{/if}}
       </div>
       <div class="form-group checkboxes">
-        {{sy-checkbox
+        <SyCheckbox
           data-test-activity-review
-          checked=this.changeset.review
-          on-change=(action (mut this.changeset.review))
-          label='Needs review'
-        }}
-        {{sy-checkbox
+          @checked={{this.changeset.review}}
+          @label={{"Needs review"}}
+          {{on "change" (fn this.toggle "review")}}
+        />
+        <SyCheckbox
           data-test-activity-not-billable
-          checked=this.changeset.notBillable
-          on-change=(action (mut this.changeset.notBillable))
-          label='Not billable'
-        }}
+          @checked={{this.changeset.notBillable}}
+          @label="Not billable"
+          {{on "change" (fn this.toggle "notBillable")}}
+        />
       </div>
       <table class="table table--striped table--activity-edit">
         <tbody>
-          <tr
-            data-test-activity-block-row
-          >
+          <tr data-test-activity-block-row>
             <td class="form-group {{if this.changeset.error.from 'has-error'}}">
-              {{sy-timepicker
-                value        = this.changeset.from
-                max          = this.changeset.to
-                precision    = 1
-                on-focus-out = (action 'validateChangeset' this.changeset)
-                on-change    = (action (mut this.changeset.from))
-              }}
+              <SyTimepicker
+                @value={{this.changeset.from}}
+                @max={{this.changeset.to}}
+                @precision={{1}}
+                @onFocusOut={{(fn this.validateChangeset this.changeset)}}
+                @onChange={{(fn (mut this.changeset.from))}}
+              />
             </td>
             <td>-</td>
             <td class="form-group {{if this.changeset.error.to 'has-error'}}">
-              {{sy-timepicker
-                value        = this.changeset.to
-                min          = this.changeset.from
-                precision    = 1
-                disabled     = (if this.changeset.active true)
-                on-focus-out = (action 'validateChangeset' this.changeset)
-                on-change    = (action (mut this.changeset.to))
-              }}
+              <SyTimepicker
+                @value={{this.changeset.to}}
+                @min={{this.changeset.from}}
+                @precision={{1}}
+                @disabled={{(if this.changeset.active true)}}
+                @onFocusOut={{(fn this.validateChangeset this.changeset)}}
+                @onChange={{(fn (mut this.changeset.to))}}
+              />
             </td>
           </tr>
         </tbody>
       </table>
     </div>
     <div class="card-footer text-right">
-      <button class="btn btn-danger" type="button" disabled={{this.model.active}} {{action 'delete'}} data-test-activity-edit-form-delete>Delete</button>
-      <button class="btn btn-primary" type="submit" disabled={{not this.saveEnabled}} data-test-activity-edit-form-save>Save</button>
+      <button
+        class="btn btn-danger"
+        type="button"
+        disabled={{@model.active}}
+        {{on "click" this.delete}}
+        data-test-activity-edit-form-delete
+      >Delete</button>
+      <button
+        class="btn btn-primary"
+        type="submit"
+        disabled={{not this.saveEnabled}}
+        data-test-activity-edit-form-save
+      >Save</button>
     </div>
   </div>
 </form>

--- a/app/index/activities/edit/template.hbs
+++ b/app/index/activities/edit/template.hbs
@@ -9,7 +9,11 @@
       <LinkTo @route="index.activities">{{fa-icon "chevron-left"}}</LinkTo>
     </div>
     <div class="card-block">
-      <TaskSelection @task={{this.changeset.task}} as |t|>
+      <TaskSelection
+        @task={{this.changeset.task}}
+        @on-set-task={{fn (mut this.changeset.task)}}
+        as |t|
+      >
         <div class="form-group">{{t.customer}}</div>
         <div class="form-group">{{t.project}}</div>
         <div class="form-group">{{t.task}}</div>

--- a/app/index/activities/edit/template.hbs
+++ b/app/index/activities/edit/template.hbs
@@ -39,13 +39,13 @@
           data-test-activity-review
           @checked={{this.changeset.review}}
           @label={{"Needs review"}}
-          @onChange={{(fn this.toggle "review")}}
+          @onChange={{toggle "review" this.changeset}}
         />
         <SyCheckbox
           data-test-activity-not-billable
           @checked={{this.changeset.notBillable}}
           @label="Not billable"
-          @onChange={{(fn this.toggle "notBillable")}}
+          @onChange={{toggle "notBillable" this.changeset}}
         />
       </div>
       <table class="table table--striped table--activity-edit">

--- a/app/index/activities/edit/template.hbs
+++ b/app/index/activities/edit/template.hbs
@@ -39,13 +39,13 @@
           data-test-activity-review
           @checked={{this.changeset.review}}
           @label={{"Needs review"}}
-          {{on "change" (fn this.toggle "review")}}
+          @onChange={{(fn this.toggle "review")}}
         />
         <SyCheckbox
           data-test-activity-not-billable
           @checked={{this.changeset.notBillable}}
           @label="Not billable"
-          {{on "change" (fn this.toggle "notBillable")}}
+          @onChange={{(fn this.toggle "notBillable")}}
         />
       </div>
       <table class="table table--striped table--activity-edit">

--- a/app/index/activities/template.hbs
+++ b/app/index/activities/template.hbs
@@ -18,25 +18,31 @@
       <table class="table table--striped table--activities">
         <tbody>
           {{#each this.sortedActivities as |activity|}}
-          <tr
-            title={{unless activity.transferred "Click to edit"}}
-            data-test-activity-row
-            data-test-activity-row-id={{activity.id}}
-            class="{{if activity.transferred 'transferred' 'pointer'}} {{if activity.active 'primary'}} {{if (eq activity.id this.editId) 'selected'}}"
-            {{on "click" (fn this.editActivity activity)}}
-          >
+            <tr
+              title={{unless activity.transferred "Click to edit"}}
+              data-test-activity-row
+              data-test-activity-row-id={{activity.id}}
+              class="{{if activity.transferred 'transferred' 'pointer'}}
+                {{if activity.active 'primary'}}
+                {{if (eq activity.id this.editId) 'selected'}}"
+              {{on "click" (fn this.editActivity activity)}}
+            >
               <td>
-                {{moment-format activity.from 'HH:mm'}}
+                {{moment-format activity.from "HH:mm"}}
                 -
                 {{#unless activity.active}}
-                  {{moment-format activity.to 'HH:mm'}}
+                  {{moment-format activity.to "HH:mm"}}
                 {{/unless}}
               </td>
-              <td title='{{activity.task.project.customer.name}} > {{activity.task.project.name}} > {{activity.task.name}}'>
+              <td
+                title="{{activity.task.project.customer.name}} > {{activity.task.project.name}} > {{activity.task.name}}"
+              >
                 {{#if activity.task}}
                   <div>
-                    {{activity.task.project.customer.name}} <strong>&gt;</strong>
-                    {{activity.task.project.name}} <strong>&gt;</strong>
+                    {{activity.task.project.customer.name}}
+                    <strong>&gt;</strong>
+                    {{activity.task.project.name}}
+                    <strong>&gt;</strong>
                     {{activity.task.name}}
                   </div>
                 {{else}}
@@ -45,13 +51,15 @@
               </td>
               <td title={{activity.comment}}>
                 <div class="comment-field">{{activity.comment}}</div>
-                {{#if activity.task.project.customerVisible }}
+                {{#if activity.task.project.customerVisible}}
                   <CustomerVisibleIcon class="activity-customer-visible-icon" />
                 {{/if}}
               </td>
               <td>
-                <div><SyCheckmark @checked={{activity.review}} /> Needs review</div>
-                <div><SyCheckmark @checked={{activity.notBillable}} /> Not billable</div>
+                <div><SyCheckmark @checked={{activity.review}} />
+                  Needs review</div>
+                <div><SyCheckmark @checked={{activity.notBillable}} />
+                  Not billable</div>
               </td>
               <td>
                 {{#if activity.active}}
@@ -68,7 +76,7 @@
                     class="btn btn-danger"
                     {{on "click" (fn this.stopActivity activity)}}
                   >
-                    {{fa-icon 'stop'}}
+                    {{fa-icon "stop"}}
                   </button>
                 {{else}}
                   <button
@@ -77,7 +85,7 @@
                     class="btn btn-success"
                     {{on "click" (fn this.startActivity activity)}}
                   >
-                    {{fa-icon 'play'}}
+                    {{fa-icon "play"}}
                   </button>
                 {{/if}}
               </td>
@@ -99,10 +107,29 @@
     Overlapping activities will not be taken into account for the timesheet.
   </modal.body>
   <modal.footer>
-   <button class="btn btn-primary" {{on "click" (if this.showUnknownWarning (fn (mut this.showOverlappingWarning) false) this.generateReports)}}>That's fine</button>
-   <button class="btn btn-default" {{on "click" (queue (fn (mut this.showOverlappingWarning) false) (fn (mut this.showUnknownWarning) false))}}>Cancel</button>
+    <button
+      class="btn btn-primary"
+      {{on
+        "click"
+        (if
+          this.showUnknownWarning
+          (fn (mut this.showOverlappingWarning) false)
+          this.generateReports
+        )
+      }}
+    >That's fine</button>
+    <button
+      class="btn btn-default"
+      {{on
+        "click"
+        (queue
+          (fn (mut this.showOverlappingWarning) false)
+          (fn (mut this.showUnknownWarning) false)
+        )
+      }}
+    >Cancel</button>
   </modal.footer>
-  </SyModal>
+</SyModal>
 
 <SyModal @visible={{this.showUnknownWarning}} as |modal|>
   <modal.header>
@@ -112,7 +139,26 @@
     Unknown tasks will not be taken into account for the timesheet.
   </modal.body>
   <modal.footer>
-   <button class="btn btn-primary" {{on "click" (if this.showOverlappingWarning (fn (mut this.showUnknownWarning) false) this.generateReports)}}>That's fine</button>
-   <button class="btn btn-default" {{on "click" (queue (fn (mut this.showUnknownWarning) false) (fn (mut this.showOverlappingWarning) false))}}>Cancel</button>
+    <button
+      class="btn btn-primary"
+      {{on
+        "click"
+        (if
+          this.showOverlappingWarning
+          (fn (mut this.showUnknownWarning) false)
+          this.generateReports
+        )
+      }}
+    >That's fine</button>
+    <button
+      class="btn btn-default"
+      {{on
+        "click"
+        (queue
+          (fn (mut this.showUnknownWarning) false)
+          (fn (mut this.showOverlappingWarning) false)
+        )
+      }}
+    >Cancel</button>
   </modal.footer>
 </SyModal>

--- a/app/index/attendances/template.hbs
+++ b/app/index/attendances/template.hbs
@@ -22,10 +22,10 @@
                 data-test-attendance-slider
                 data-test-attendance-slider-id={{attendance.id}}>
                 <td>
-                  {{sy-timepicker value=model.from on-change=(action (mut model.from))}}
+                  {{sy-timepicker value=model.from onChange=(action (mut model.from))}}
                 </td>
                 <td>
-                  {{sy-timepicker value=model.to on-change=(action (mut model.to))}}
+                  {{sy-timepicker value=model.to onChange=(action (mut model.to))}}
                 </td>
                 <td>
                   <button type="button" class="btn btn-danger" {{action 'deleteAttendance' model}}>{{fa-icon 'trash'}}</button>

--- a/app/index/reports/controller.js
+++ b/app/index/reports/controller.js
@@ -4,7 +4,6 @@
  * @public
  */
 import Controller from "@ember/controller";
-import { computed } from "@ember/object";
 import ReportValidations from "timed/validations/report";
 
 /**
@@ -14,10 +13,10 @@ import ReportValidations from "timed/validations/report";
  * @extends Ember.Controller
  * @public
  */
-export default Controller.extend({
-  ReportValidations,
+export default class IndexReportController extends Controller {
+  ReportValidations = ReportValidations;
 
-  showReschedule: false,
+  showReschedule = false;
 
   /**
    * All reports currently in the store
@@ -25,9 +24,9 @@ export default Controller.extend({
    * @property {Report[]} _allReports
    * @private
    */
-  _allReports: computed(function() {
+  get _allReports() {
     return this.store.peekAll("report");
-  }),
+  }
 
   /**
    * The reports filtered by the selected day
@@ -37,27 +36,22 @@ export default Controller.extend({
    * @property {Report[]} reports
    * @public
    */
-  reports: computed(
-    "_allReports.@each.{user,date,isNew,isDeleted}",
-    "model",
-    "user",
-    function() {
-      const reportsToday = this._allReports.filter(r => {
-        return (
-          (!r.get("user.id") || r.get("user.id") === this.get("user.id")) &&
-          r.get("date").isSame(this.model, "day") &&
-          !r.get("isDeleted")
-        );
+  get reports() {
+    const reportsToday = this._allReports.filter((r) => {
+      return (
+        (!r.get("user.id") || r.get("user.id") === this.get("user.id")) &&
+        r.get("date").isSame(this.model, "day") &&
+        !r.get("isDeleted")
+      );
+    });
+
+    if (!reportsToday.filterBy("isNew", true).get("length")) {
+      this.store.createRecord("report", {
+        date: this.model,
+        user: this.user,
       });
-
-      if (!reportsToday.filterBy("isNew", true).get("length")) {
-        this.store.createRecord("report", {
-          date: this.model,
-          user: this.user
-        });
-      }
-
-      return reportsToday.sort(a => (a.get("isNew") ? 1 : 0));
     }
-  )
-});
+
+    return reportsToday.sort((a) => (a.get("isNew") ? 1 : 0));
+  }
+}

--- a/app/index/reports/route.js
+++ b/app/index/reports/route.js
@@ -4,8 +4,6 @@
  * @public
  */
 import Route from "@ember/routing/route";
-import { inject as service } from "@ember/service";
-import { all } from "rsvp";
 import RouteAutostartTourMixin from "timed/mixins/route-autostart-tour";
 
 /**
@@ -15,15 +13,9 @@ import RouteAutostartTourMixin from "timed/mixins/route-autostart-tour";
  * @extends Ember.Route
  * @public
  */
-export default Route.extend(RouteAutostartTourMixin, {
-  /**
-   * The notify service
-   *
-   * @property {EmberNotify.NotifyService} notify
-   * @public
-   */
-  notify: service("notify"),
-
+export default class IndexReportsRoute extends Route.extend(
+  RouteAutostartTourMixin
+) {
   /**
    * Before model hook, fetch all absence types
    *
@@ -32,94 +24,15 @@ export default Route.extend(RouteAutostartTourMixin, {
    * @public
    */
   beforeModel(...args) {
-    this._super(...args);
+    super.beforeModel(...args);
 
     return this.store.findAll("absence-type");
-  },
+  }
 
   setupController(controller, model, ...args) {
-    this._super(controller, model, ...args);
+    super.setupController(controller, model, ...args);
 
     controller.set("user", this.modelFor("protected"));
     controller.set("rescheduleDate", model);
-  },
-
-  /**
-   * Actions for the index report route
-   *
-   * @property {Object} actions
-   * @public
-   */
-  actions: {
-    /**
-     * Save a certain report and close the modal afterwards
-     *
-     * @method saveReport
-     * @param {Report} report The report to save
-     * @public
-     */
-    async saveReport(report) {
-      try {
-        this.send("loading");
-
-        await report.save();
-
-        const absence = this.controllerFor("index").get("absence");
-
-        if (absence) {
-          await absence.reload();
-        }
-      } catch (e) {
-        /* istanbul ignore next */
-        this.notify.error("Error while saving the report");
-      } finally {
-        this.send("finished");
-      }
-    },
-
-    /**
-     * Delete a certain report and close the modal afterwards
-     *
-     * @method deleteReport
-     * @param {Report} report The report to delete
-     * @public
-     */
-    async deleteReport(report) {
-      try {
-        this.send("loading");
-
-        await report.destroyRecord();
-
-        if (!report.get("isNew")) {
-          const absence = this.controllerFor("index").get("absence");
-
-          if (absence) {
-            await absence.reload();
-          }
-        }
-      } catch (e) {
-        /* istanbul ignore next */
-        this.notify.error("Error while deleting the report");
-      } finally {
-        this.send("finished");
-      }
-    },
-
-    async reschedule(date) {
-      try {
-        const reports = this.get("controller.reports").filterBy("isNew", false);
-        await all(
-          reports.map(async report => {
-            report.set("date", date);
-            return await report.save();
-          })
-        );
-        this.set("controller.showReschedule", false);
-        this.controllerFor("index").set("date", date);
-      } catch (e) {
-        /* istanbul ignore next */
-        this.notify.error("Error while rescheduling the timesheet");
-      }
-    }
   }
-});
+}

--- a/app/index/reports/template.hbs
+++ b/app/index/reports/template.hbs
@@ -1,34 +1,55 @@
 <div class="btn-toolbar btn-toolbar--right form-group">
-  <button type="button" class="btn btn-success" title="Move all entries to another date" data-test-report-reschedule {{action (mut this.showReschedule) true}}>Reschedule</button>
+  <button
+    type="button"
+    class="btn btn-success"
+    title="Move all entries to another date"
+    data-test-report-reschedule
+    {{on "click" (fn (mut this.showReschedule) true)}}
+  >Reschedule</button>
 </div>
 
 <div class="form-list form-list--reports">
   <div class="form-list-body">
     {{#each this.reports as |report|}}
-      {{report-row
-        report
+      <ReportRow
+        @report={{report}}
+        @onSave={{route-action "saveReport"}}
+        @onDelete={{route-action "deleteReport"}}
+        data-test-report-row-id={{report.id}}
         data-test-report-row
-        data-test-report-row-id = report.id
-        on-save                 = (route-action 'saveReport')
-        on-delete               = (route-action 'deleteReport')
-      }}
+      />
     {{/each}}
   </div>
 </div>
 
-{{#sy-modal visible=this.showReschedule size="small" as |modal|}}
+<SyModal @visible={{this.showReschedule}} @size="small" as |modal|>
   <modal.header>
     Reschedule timesheet
   </modal.header>
   <modal.body>
-    <PowerCalendar @class="calendar" @center={{this.center}} @selected={{this.rescheduleDate}} @onCenterChange={{action (mut this.center) value='moment'}} @onSelect={{action (mut this.rescheduleDate) value='moment'}} as |calendar|>
-      <div class={{if calendar.loading 'loading-mask'}}>
+    <PowerCalendar
+      @class="calendar"
+      @center={{this.center}}
+      @selected={{this.rescheduleDate}}
+      @onCenterChange={{action (mut this.center) value="moment"}}
+      @onSelect={{action (mut this.rescheduleDate) value="moment"}}
+      as |calendar|
+    >
+      <div class={{if calendar.loading "loading-mask"}}>
         {{calendar.nav}}
-        <calendar.days @disabledDates={{this.disabledDates}} @startOfWeek={{1}} />
+        <calendar.days
+          @disabledDates={{this.disabledDates}}
+          @startOfWeek={{1}}
+        />
       </div>
     </PowerCalendar>
   </modal.body>
   <modal.footer>
-    <button type="submit" class="btn btn-primary" data-test-report-save {{action 'reschedule' this.rescheduleDate}}>Save</button>
+    <button
+      type="submit"
+      class="btn btn-primary"
+      data-test-report-save
+      {{on "click" (fn this.reschedule this.rescheduleDate)}}
+    >Save</button>
   </modal.footer>
-{{/sy-modal}}
+</SyModal>

--- a/app/index/reports/template.hbs
+++ b/app/index/reports/template.hbs
@@ -13,8 +13,8 @@
     {{#each this.reports as |report|}}
       <ReportRow
         @report={{report}}
-        @onSave={{route-action "saveReport"}}
-        @onDelete={{route-action "deleteReport"}}
+        @onSave={{this.saveReport}}
+        @onDelete={{this.deleteReport}}
         data-test-report-row-id={{report.id}}
         data-test-report-row
       />
@@ -22,22 +22,27 @@
   </div>
 </div>
 
-<SyModal @visible={{this.showReschedule}} @size="small" as |modal|>
+<SyModal
+  @visible={{this.showReschedule}}
+  @on-close={{toggle "showReschedule" this}}
+  @size="small"
+  as |modal|
+>
   <modal.header>
     Reschedule timesheet
   </modal.header>
   <modal.body>
     <PowerCalendar
-      @class="calendar"
+      class="calendar"
       @center={{this.center}}
       @selected={{this.rescheduleDate}}
-      @onCenterChange={{action (mut this.center) value="moment"}}
-      @onSelect={{action (mut this.rescheduleDate) value="moment"}}
+      @onCenterChange={{(pick "moment" (fn (mut this.center)))}}
+      @onSelect={{(pick "moment" (fn (mut this.rescheduleDate)))}}
       as |calendar|
     >
       <div class={{if calendar.loading "loading-mask"}}>
-        {{calendar.nav}}
-        <calendar.days
+        {{calendar.Nav}}
+        <calendar.Days
           @disabledDates={{this.disabledDates}}
           @startOfWeek={{1}}
         />
@@ -49,7 +54,7 @@
       type="submit"
       class="btn btn-primary"
       data-test-report-save
-      {{on "click" (fn this.reschedule this.rescheduleDate)}}
+      {{on "click" (prevent-default (fn this.reschedule this.rescheduleDate))}}
     >Save</button>
   </modal.footer>
 </SyModal>

--- a/app/index/route.js
+++ b/app/index/route.js
@@ -19,12 +19,13 @@ const DATE_FORMAT = "YYYY-MM-DD";
  * @public
  */
 export default class IndexRoute extends Route.extend(RouteAutostartTourMixin) {
+  lastUpdateDate = null;
 
   queryParams = {
     day: {
-      refreshModel: true
-    }
-  }
+      refreshModel: true,
+    },
+  };
 
   /**
    * The session service
@@ -57,6 +58,13 @@ export default class IndexRoute extends Route.extend(RouteAutostartTourMixin) {
    * @public
    */
   afterModel(model) {
+    const formattedDate = model.format();
+    if (formattedDate === this.lastUpdateDate) {
+      return;
+    }
+
+    this.lastUpdateDate = formattedDate;
+
     const userId = this.session.data.user.id;
     const day = model.format(DATE_FORMAT);
     const from = moment(model).subtract(20, "days").format(DATE_FORMAT);

--- a/app/projects/template.hbs
+++ b/app/projects/template.hbs
@@ -5,7 +5,7 @@
     </div>
   {{else}}
     <div class="header">
-      <PowerSelect 
+      <PowerSelect
         data-test-customer-selection
         @tagName="div"
         class="header-item"
@@ -14,17 +14,17 @@
         @searchField="name"
         @onChange={{this.handleCustomerChange}}
         @selected={{this.selectedCustomer}}
-        @allowClear={{true}} 
+        @allowClear={{true}}
         as |customer|
       >
         <div>{{customer.name}}</div>
       </PowerSelect>
       <PowerSelect
-        data-test-project-selection 
+        data-test-project-selection
         @tagName="div"
-        class="header-item" 
+        class="header-item"
         @options={{this.filteredProjects}}
-        placeholder="Select project..." 
+        placeholder="Select project..."
         @searchField="name"
         @onChange={{this.handleProjectChange}}
         @selected={{this.selectedProject}}
@@ -38,44 +38,79 @@
     {{#if this.selectedProject}}
       <h3>
         <span class="header-left">
-          Tasks of {{this.selectedProject.name}}
+          Tasks of
+          {{this.selectedProject.name}}
         </span>
         <span class="header-right">
-          <button class="btn btn-primary" {{action (perform this.createTask)}} data-test-add-task>Add Task</button>
+          <button
+            class="btn btn-primary"
+            {{action (perform this.createTask)}}
+            data-test-add-task
+          >Add Task</button>
         </span>
       </h3>
       <div class="task-table-container">
         <EmberScrollable @class="projects-scrollable-container">
-          <table class="table table--striped table--projects" data-test-tasks-table>
+          <table
+            class="table table--striped table--projects"
+            data-test-tasks-table
+          >
             <thead>
-            <tr>
-              <th>Name</th>
-              <th>Reference</th>
-              <th>Estimated time</th>
-              <th>Archived</th>
-            </tr>
+              <tr>
+                <th>Name</th>
+                <th>Reference</th>
+                <th>Estimated time</th>
+                <th>Archived</th>
+              </tr>
             </thead>
             <tbody>
-            {{#each this.tasks as |task|}}
-              <tr class="pointer {{if (eq this.selectedTask task) "selected"}}" {{action (mut this.selectedTask) task}} data-test-task-table-row>
-                <td data-test-table-name>{{task.name}}</td>
-                <td data-test-table-reference>{{if task.reference task.reference "-"}}</td>
-                <td data-test-table-estimated-time>{{if task.estimatedTime (humanize-duration task.estimatedTime) "-"}}</td>
-                <td><SyCheckmark data-test-table-archived @checked={{task.archived}}/></td>
-              </tr>
-            {{/each}}
+              {{#each this.tasks as |task|}}
+                <tr
+                  class="pointer {{if (eq this.selectedTask task) 'selected'}}"
+                  {{action (mut this.selectedTask) task}}
+                  data-test-task-table-row
+                >
+                  <td data-test-table-name>{{task.name}}</td>
+                  <td data-test-table-reference>{{if
+                      task.reference
+                      task.reference
+                      "-"
+                    }}</td>
+                  <td data-test-table-estimated-time>{{if
+                      task.estimatedTime
+                      (humanize-duration task.estimatedTime)
+                      "-"
+                    }}</td>
+                  <td><SyCheckmark
+                      data-test-table-archived
+                      @checked={{task.archived}}
+                    /></td>
+                </tr>
+              {{/each}}
             </tbody>
           </table>
         </EmberScrollable>
       </div>
       {{#if this.selectedTask}}
         <div class="task-form-container" data-test-task-form>
-          <h2>{{if this.selectedTask.isNew "Add task" this.selectedTask.name}}</h2>
-          <ValidatedForm @model={{changeset this.selectedTask this.TaskValidations}} @on-submit={{perform this.saveTask}} as |f|>
+          <h2>{{if
+              this.selectedTask.isNew
+              "Add task"
+              this.selectedTask.name
+            }}</h2>
+          <ValidatedForm
+            @model={{changeset this.selectedTask this.TaskValidations}}
+            @on-submit={{perform this.saveTask}}
+            as |f|
+          >
             <div class="task-form-container-row">
               <div class="task-form-container-column">
-                <f.input  @label="Name" @name="name" @required={{true}} />
-                <f.input  @label="Reference" @name="reference" @required={{false}} />
+                <f.input @label="Name" @name="name" @required={{true}} />
+                <f.input
+                  @label="Reference"
+                  @name="reference"
+                  @required={{false}}
+                />
               </div>
               <div class="task-form-container-column">
                 <f.input @name="estimatedTime" as |fi|>
@@ -89,21 +124,25 @@
                   }}
                 </f.input>
 
-                <f.input  @name="archived" as |fi|>
+                <f.input @name="archived" as |fi|>
                   <label>
                     Archived
                   </label>
-                  {{sy-checkbox
-                    checked=this.selectedTask.archived
-                    value=fi.value
-                    on-change=fi.update
-                  }}
+                  <SyCheckbox
+                    @checked={{this.selectedTask.archived}}
+                    @value={{fi.value}}
+                    @onChange={{fi.update}}
+                  />
                 </f.input>
               </div>
             </div>
             <div class="btn-toolbar btn-toolbar--right">
-              <button class="btn btn-primary" {{action (mut this.selectedTask) null}} data-test-cancel>Cancel</button>
-              <f.submit  @disabled={{f.model.isInvalid}} />
+              <button
+                class="btn btn-primary"
+                {{action (mut this.selectedTask) null}}
+                data-test-cancel
+              >Cancel</button>
+              <f.submit @disabled={{f.model.isInvalid}} />
             </div>
           </ValidatedForm>
         </div>
@@ -111,7 +150,7 @@
     {{else}}
       <div class="empty" data-test-none-selected>
         <div>
-          {{fa-icon 'search'}}
+          {{fa-icon "search"}}
           <h3>Please select a customer and a project</h3>
         </div>
       </div>

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -29,6 +29,7 @@
 /* Component styles */
 @import "components/date-navigation";
 @import "components/tracking-bar";
+@import "components/sy-calendar";
 
 html {
   hyphens: auto;

--- a/app/styles/components/sy-calendar.scss
+++ b/app/styles/components/sy-calendar.scss
@@ -1,0 +1,47 @@
+.sy-calendar {
+  @include ember-power-calendar($cell-size: 35px);
+
+  .ember-power-calendar-nav-control {
+    color: $color-primary;
+    cursor: pointer;
+  }
+
+  .nav-select-month,
+  .nav-select-year {
+    position: relative;
+
+    select {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      opacity: 0;
+    }
+  }
+
+  .ember-power-calendar-day {
+    cursor: pointer;
+    transition: background-color 300ms ease, color 300ms ease;
+
+    &--focused {
+      box-shadow: inset 0 -2px 0 0 $color-primary;
+    }
+
+    &--selected {
+      color: rgb(255, 255, 255);
+      background-color: lighten($color-primary, 20%);
+
+      &:hover {
+        color: rgb(255, 255, 255);
+        background-color: lighten($color-primary, 30%);
+      }
+    }
+  }
+}
+
+.sy-calendar.sy-datepicker {
+  border: 1px solid $color-border;
+  padding: 0.5rem;
+  box-shadow: 2px 2px 10px rgba(0, 0, 0, 0.2);
+}

--- a/app/validators/moment.js
+++ b/app/validators/moment.js
@@ -18,7 +18,6 @@ export default function validateMoment(options = { gt: null, lt: null }) {
       newValue = moment();
     }
     let valid = !!newValue && newValue._isValid;
-
     if (!valid) {
       return valid;
     }
@@ -39,7 +38,6 @@ export default function validateMoment(options = { gt: null, lt: null }) {
         valid = false;
       }
     }
-
     return valid;
   };
 }

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "ember-concurrency": "2.3.4",
     "ember-data": "3.28.0",
     "ember-decorators": "6.1.1",
+    "ember-event-helpers": "^0.1.1",
     "ember-export-application-global": "2.0.1",
     "ember-fetch": "8.1.2",
     "ember-font-awesome": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -45,12 +45,11 @@
     "@ember/optional-features": "2.0.0",
     "@ember/render-modifiers": "2.0.4",
     "@ember/test-helpers": "2.8.1",
-    "@embroider/macros": "^1.10.0",
+    "@embroider/macros": "^1.9.0",
     "@embroider/util": "^1.9.0",
     "@fontsource/source-sans-pro": "4.5.11",
     "@glimmer/component": "1.1.2",
     "@glimmer/tracking": "1.1.2",
-    "@glint/template": ">= 0.8.3",
     "@html-next/vertical-collection": "4.0.2",
     "babel-eslint": "10.1.0",
     "broccoli-asset-rev": "3.0.0",
@@ -148,6 +147,7 @@
     "peerDependencyRules": {
       "ignoreMissing": [
         "@babel/core",
+        "@glint/template@",
         "@types/node"
       ]
     }

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "peerDependencyRules": {
       "ignoreMissing": [
         "@babel/core",
-        "@glint/template@",
+        "@glint/template",
         "@types/node"
       ]
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,12 +12,11 @@ specifiers:
   '@ember/optional-features': 2.0.0
   '@ember/render-modifiers': 2.0.4
   '@ember/test-helpers': 2.8.1
-  '@embroider/macros': ^1.10.0
+  '@embroider/macros': ^1.9.0
   '@embroider/util': ^1.9.0
   '@fontsource/source-sans-pro': 4.5.11
   '@glimmer/component': 1.1.2
   '@glimmer/tracking': 1.1.2
-  '@glint/template': '>= 0.8.3'
   '@html-next/vertical-collection': 4.0.2
   babel-eslint: 10.1.0
   broccoli-asset-rev: 3.0.0
@@ -116,7 +115,6 @@ devDependencies:
   '@fontsource/source-sans-pro': 4.5.11
   '@glimmer/component': 1.1.2
   '@glimmer/tracking': 1.1.2
-  '@glint/template': 0.9.7_@glimmer+component@1.1.2
   '@html-next/vertical-collection': 4.0.2
   babel-eslint: 10.1.0_eslint@7.32.0
   broccoli-asset-rev: 3.0.0
@@ -166,7 +164,7 @@ devDependencies:
   ember-power-select: 6.0.1_ember-source@3.28.0
   ember-qunit: 6.0.0_qlun7vkcguccocg2zpe7gp5kwa
   ember-resolver: 8.0.3
-  ember-resources: 5.6.0_dbrt6eyp6y45rcwnqrscmaa2xy
+  ember-resources: 5.6.0_7agcew7zbr4wazpzfljptmrzjm
   ember-responsive: 5.0.0
   ember-route-action-helper: 2.0.8
   ember-scrollable: 1.0.2
@@ -2691,14 +2689,6 @@ packages:
       babel-plugin-debug-macros: 0.3.4
     transitivePeerDependencies:
       - '@babel/core'
-    dev: true
-
-  /@glint/template/0.9.7_@glimmer+component@1.1.2:
-    resolution: {integrity: sha512-MCp8GxQDIbH8ZzfNxHhVqCSKlydBgQfBEwJLDpN81lgFRCldSDPueIbk8sz3EhpGiZJVdNQbpGeYIDsUXe1ocg==}
-    peerDependencies:
-      '@glimmer/component': ^1.1.2
-    dependencies:
-      '@glimmer/component': 1.1.2
     dev: true
 
   /@handlebars/parser/2.0.0:
@@ -9075,7 +9065,7 @@ packages:
       - supports-color
     dev: true
 
-  /ember-resources/5.6.0_dbrt6eyp6y45rcwnqrscmaa2xy:
+  /ember-resources/5.6.0_7agcew7zbr4wazpzfljptmrzjm:
     resolution: {integrity: sha512-yTI3u3JV7/WxdbX/+9lB3DoeHLiHg993F1vMw/3bVtr7i9f8f2TQUoeIxp+jzCk2Ozjm4zb+x+/DuSIx1FzyJA==}
     peerDependencies:
       '@ember/test-waiters': ^3.0.0
@@ -9097,7 +9087,6 @@ packages:
       '@embroider/macros': 1.10.0
       '@glimmer/component': 1.1.2
       '@glimmer/tracking': 1.1.2
-      '@glint/template': 0.9.7_@glimmer+component@1.1.2
       ember-concurrency: 2.2.1
       ember-source: 3.28.0
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9079,6 +9079,8 @@ packages:
         optional: true
       '@glimmer/component':
         optional: true
+      '@glint/template':
+        optional: true
       ember-concurrency:
         optional: true
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,7 @@ specifiers:
   ember-concurrency: ^2.1.1
   ember-data: 3.28.0
   ember-decorators: 6.1.1
+  ember-event-helpers: ^0.1.1
   ember-export-application-global: 2.0.1
   ember-fetch: 8.1.2
   ember-font-awesome: 3.1.1
@@ -148,6 +149,7 @@ devDependencies:
   ember-concurrency: 2.2.1
   ember-data: 3.28.0
   ember-decorators: 6.1.1
+  ember-event-helpers: 0.1.1
   ember-export-application-global: 2.0.1
   ember-fetch: 8.1.2
   ember-font-awesome: 3.1.1
@@ -8685,6 +8687,15 @@ packages:
       ember-cli-htmlbars: 2.0.5
     transitivePeerDependencies:
       - '@babel/core'
+      - supports-color
+    dev: true
+
+  /ember-event-helpers/0.1.1:
+    resolution: {integrity: sha512-fWcbWd4W4nRv8bbato8JB6oGRpATkR+oGYxMIqnfgTgPWaCS0ww7CuUVNpwg1TulojKMCuTXi8Fem2b1NSF1ZQ==}
+    engines: {node: 8.* || >= 10.*}
+    dependencies:
+      ember-cli-babel: 7.26.11
+    transitivePeerDependencies:
       - supports-color
     dev: true
 

--- a/tests/integration/components/sy-checkbox/component-test.js
+++ b/tests/integration/components/sy-checkbox/component-test.js
@@ -1,28 +1,28 @@
-import { hbs } from 'ember-cli-htmlbars';
 import { click, find, render } from "@ember/test-helpers";
+import { hbs } from "ember-cli-htmlbars";
 import { setupRenderingTest } from "ember-qunit";
 import { module, test } from "qunit";
 
-module("Integration | Component | sy checkbox", function(hooks) {
+module("Integration | Component | sy checkbox", function (hooks) {
   setupRenderingTest(hooks);
 
-  test("works", async function(assert) {
-    await render(hbs`{{sy-checkbox label='Test Label'}}`);
+  test("works", async function (assert) {
+    await render(hbs`<SyCheckbox @label='Test Label' />`);
 
     assert.dom("label").hasText("Test Label");
   });
 
-  test("works in block style", async function(assert) {
-    await render(hbs`{{#sy-checkbox}}Test Label{{/sy-checkbox}}`);
+  test("works in block style", async function (assert) {
+    await render(hbs`<SyCheckbox>Test Label</SyCheckbox>`);
 
     assert.dom("label").hasText("Test Label");
   });
 
-  test("changes state", async function(assert) {
+  test("changes state", async function (assert) {
     this.set("checked", false);
 
     await render(
-      hbs`{{sy-checkbox checked=checked on-change=(action (mut checked))}}`
+      hbs`<SyCheckbox @checked={{this.checked}} @onChange={{(fn (mut this.checked))}} />`
     );
 
     assert.dom("input").isNotChecked();
@@ -39,11 +39,11 @@ module("Integration | Component | sy checkbox", function(hooks) {
     assert.notOk(this.checked);
   });
 
-  test("can be indeterminate", async function(assert) {
+  test("can be indeterminate", async function (assert) {
     this.set("checked", null);
 
     await render(
-      hbs`{{sy-checkbox checked=checked on-change=(action (mut checked))}}`
+      hbs`<SyCheckbox @checked={{this.checked}} @onChange={{(fn (mut this.checked))}} />`
     );
 
     assert.ok(find("input").indeterminate);

--- a/tests/integration/components/sy-checkmark/component-test.js
+++ b/tests/integration/components/sy-checkmark/component-test.js
@@ -1,18 +1,18 @@
-import { hbs } from 'ember-cli-htmlbars';
 import { render } from "@ember/test-helpers";
+import { hbs } from "ember-cli-htmlbars";
 import { setupRenderingTest } from "ember-qunit";
 import { module, test } from "qunit";
 
-module("Integration | Component | sy checkmark", function(hooks) {
+module("Integration | Component | sy checkmark", function (hooks) {
   setupRenderingTest(hooks);
 
-  test("works unchecked", async function(assert) {
-    await render(hbs`{{sy-checkmark checked=false}}`);
+  test("works unchecked", async function (assert) {
+    await render(hbs`<SyCheckmark @checked={{false}} />`);
     assert.dom(".fa-square-o").exists({ count: 1 });
   });
 
-  test("works checked", async function(assert) {
-    await render(hbs`{{sy-checkmark checked=true}}`);
+  test("works checked", async function (assert) {
+    await render(hbs`<SyCheckmark @checked={{true}} />`);
     assert.dom(".fa-check-square-o").exists({ count: 1 });
   });
 });

--- a/tests/integration/components/sy-durationpicker/component-test.js
+++ b/tests/integration/components/sy-durationpicker/component-test.js
@@ -1,46 +1,46 @@
-import { hbs } from 'ember-cli-htmlbars';
 import {
   fillIn,
   blur,
   render,
   triggerKeyEvent,
-  settled
+  settled,
 } from "@ember/test-helpers";
+import { hbs } from "ember-cli-htmlbars";
 import { setupRenderingTest } from "ember-qunit";
 import moment from "moment";
 import { module, test } from "qunit";
 import formatDuration from "timed/utils/format-duration";
 
-module("Integration | Component | sy durationpicker", function(hooks) {
+module("Integration | Component | sy durationpicker", function (hooks) {
   setupRenderingTest(hooks);
 
-  test("renders", async function(assert) {
+  test("renders", async function (assert) {
     this.set("value", moment.duration({ h: 1, m: 30 }));
 
-    await render(hbs`{{sy-durationpicker value=value}}`);
+    await render(hbs`<SyDurationpicker @value={{this.value}} />`);
 
     assert.dom("input").hasValue("01:30");
   });
 
-  test("renders without value", async function(assert) {
+  test("renders without value", async function (assert) {
     this.set("value", null);
 
-    await render(hbs`{{sy-durationpicker value=value}}`);
+    await render(hbs`<SyDurationpicker @value={{this.value}} />`);
 
     assert.dom("input").hasNoValue();
   });
 
-  test("can change the value", async function(assert) {
+  test("can change the value", async function (assert) {
     this.set(
       "value",
       moment.duration({
         h: 12,
-        m: 30
+        m: 30,
       })
     );
 
     await render(
-      hbs`{{sy-durationpicker value=value on-change=(action (mut value))}}`
+      hbs`<SyDurationpicker @value={{this.value}} @onChange={{fn (mut this.value)}} />`
     );
 
     await fillIn("input", "13:15");
@@ -50,17 +50,17 @@ module("Integration | Component | sy durationpicker", function(hooks) {
     assert.equal(this.value.minutes(), 15);
   });
 
-  test("can set a negative value", async function(assert) {
+  test("can set a negative value", async function (assert) {
     this.set(
       "value",
       moment.duration({
         h: 12,
-        m: 30
+        m: 30,
       })
     );
 
     await render(
-      hbs`{{sy-durationpicker value=value on-change=(action (mut value))}}`
+      hbs`<SyDurationpicker @value={{this.value}} @onChange={{fn (mut this.value)}} />`
     );
 
     await fillIn("input", "-13:00");
@@ -69,17 +69,17 @@ module("Integration | Component | sy durationpicker", function(hooks) {
     assert.equal(this.value.hours(), -13);
   });
 
-  test("can't set an invalid value", async function(assert) {
+  test("can't set an invalid value", async function (assert) {
     this.set(
       "value",
       moment.duration({
         h: 12,
-        m: 30
+        m: 30,
       })
     );
 
     await render(
-      hbs`{{sy-durationpicker value=value on-change=(action (mut value))}}`
+      hbs`<SyDurationpicker @value={{this.value}} @onChange={{fn (mut this.value)}} />`
     );
 
     await fillIn("input", "abcdef");
@@ -89,22 +89,24 @@ module("Integration | Component | sy durationpicker", function(hooks) {
     assert.equal(this.value.minutes(), 30);
   });
 
-  test("can increase minutes per arrow", async function(assert) {
+  test("can increase minutes per arrow", async function (assert) {
     this.set(
       "value",
       moment.duration({
         h: 12,
-        m: 15
+        m: 15,
       })
     );
 
     await render(
-      hbs`{{sy-durationpicker value=value on-change=(action (mut value))}}`
+      hbs`<SyDurationpicker @value={{this.value}} @onChange={{fn (mut this.value)}} />`
     );
 
     this.element
       .querySelectorAll("input")
-      .forEach(async element => await triggerKeyEvent(element, "keydown", 38));
+      .forEach(
+        async (element) => await triggerKeyEvent(element, "keydown", 38)
+      );
 
     await settled();
 
@@ -112,22 +114,24 @@ module("Integration | Component | sy durationpicker", function(hooks) {
     assert.equal(this.value.minutes(), 30);
   });
 
-  test("can decrease minutes per arrow", async function(assert) {
+  test("can decrease minutes per arrow", async function (assert) {
     this.set(
       "value",
       moment.duration({
         h: 12,
-        m: 15
+        m: 15,
       })
     );
 
     await render(
-      hbs`{{sy-durationpicker value=value on-change=(action (mut value))}}`
+      hbs`<SyDurationpicker @value={{this.value}} @onChange={{fn (mut this.value)}} />`
     );
 
     this.element
       .querySelectorAll("input")
-      .forEach(async element => await triggerKeyEvent(element, "keydown", 40));
+      .forEach(
+        async (element) => await triggerKeyEvent(element, "keydown", 40)
+      );
 
     await settled();
 
@@ -135,12 +139,12 @@ module("Integration | Component | sy durationpicker", function(hooks) {
     assert.equal(this.value.minutes(), 0);
   });
 
-  test("can't be bigger than max or smaller than min", async function(assert) {
+  test("can't be bigger than max or smaller than min", async function (assert) {
     this.set(
       "value",
       moment.duration({
         h: 12,
-        m: 30
+        m: 30,
       })
     );
 
@@ -148,7 +152,7 @@ module("Integration | Component | sy durationpicker", function(hooks) {
       "min",
       moment.duration({
         h: 12,
-        m: 30
+        m: 30,
       })
     );
 
@@ -156,17 +160,19 @@ module("Integration | Component | sy durationpicker", function(hooks) {
       "max",
       moment.duration({
         h: 12,
-        m: 30
+        m: 30,
       })
     );
 
     await render(
-      hbs`{{sy-durationpicker min=min max=max value=value on-change=(action (mut value))}}`
+      hbs`<SyDurationpicker @min={{this.min}} @max={{this.max}} @value={{this.value}} @onChange={{fn (mut this.value)}} />`
     );
 
     this.element
       .querySelectorAll("input")
-      .forEach(async element => await triggerKeyEvent(element, "keydown", 38));
+      .forEach(
+        async (element) => await triggerKeyEvent(element, "keydown", 38)
+      );
 
     await settled();
 
@@ -175,7 +181,9 @@ module("Integration | Component | sy durationpicker", function(hooks) {
 
     this.element
       .querySelectorAll("input")
-      .forEach(async element => await triggerKeyEvent(element, "keydown", 40));
+      .forEach(
+        async (element) => await triggerKeyEvent(element, "keydown", 40)
+      );
 
     await settled();
 
@@ -183,11 +191,11 @@ module("Integration | Component | sy durationpicker", function(hooks) {
     assert.equal(this.value.minutes(), 30);
   });
 
-  test("can set a negative value with minutes", async function(assert) {
+  test("can set a negative value with minutes", async function (assert) {
     this.set("value", null);
 
     await render(
-      hbs`{{sy-durationpicker value=value on-change=(action (mut value))}}`
+      hbs`<SyDurationpicker @value={{this.value}} @onChange={{fn (mut this.value)}} />`
     );
 
     await fillIn("input", "-04:30");

--- a/tests/integration/components/sy-timepicker/component-test.js
+++ b/tests/integration/components/sy-timepicker/component-test.js
@@ -16,7 +16,7 @@ module("Integration | Component | sy timepicker", function(hooks) {
   test("renders", async function(assert) {
     this.set("value", moment());
 
-    await render(hbs`{{sy-timepicker value=value}}`);
+    await render(hbs`<SyTimepicker @value={{this.value}} />`);
 
     assert.dom("input").hasValue(moment().format("HH:mm"));
   });
@@ -31,7 +31,7 @@ module("Integration | Component | sy timepicker", function(hooks) {
     );
 
     await render(
-      hbs`{{sy-timepicker value=value on-change=(action (mut value))}}`
+      hbs`<SyTimepicker @value={{this.value}} @onChange={{fn (mut this.value)}} />`
     );
 
     await fillIn("input", "13:15");
@@ -51,7 +51,7 @@ module("Integration | Component | sy timepicker", function(hooks) {
     );
 
     await render(
-      hbs`{{sy-timepicker value=value on-change=(action (mut value))}}`
+      hbs`<SyTimepicker @value={{this.value}} @onChange={{fn (mut this.value)}} />`
     );
 
     await fillIn("input", "24:15");
@@ -65,7 +65,7 @@ module("Integration | Component | sy timepicker", function(hooks) {
     this.set("value", null);
 
     await render(
-      hbs`{{sy-timepicker value=value on-change=(action (mut value))}}`
+      hbs`<SyTimepicker @value={{this.value}} @onChange={{fn (mut this.value)}} />`
     );
 
     await fillIn("input", "xx:xx");
@@ -89,7 +89,7 @@ module("Integration | Component | sy timepicker", function(hooks) {
     );
 
     await render(
-      hbs`{{sy-timepicker value=value on-change=(action (mut value))}}`
+      hbs`<SyTimepicker @value={{this.value}} @onChange={{fn (mut this.value)}} />`
     );
 
     this.element
@@ -112,7 +112,7 @@ module("Integration | Component | sy timepicker", function(hooks) {
     );
 
     await render(
-      hbs`{{sy-timepicker value=value on-change=(action (mut value))}}`
+      hbs`<SyTimepicker @value={{this.value}} @onChange={{fn (mut this.value)}} />`
     );
 
     this.element
@@ -135,7 +135,7 @@ module("Integration | Component | sy timepicker", function(hooks) {
     );
 
     await render(
-      hbs`{{sy-timepicker value=value on-change=(action (mut value))}}`
+      hbs`<SyTimepicker @value={{this.value}} @onChange={{fn (mut this.value)}} />`
     );
 
     this.element
@@ -161,7 +161,7 @@ module("Integration | Component | sy timepicker", function(hooks) {
     );
 
     await render(
-      hbs`{{sy-timepicker value=value on-change=(action (mut value))}}`
+      hbs`<SyTimepicker @value={{this.value}} @onChange={{fn (mut this.value)}} />`
     );
 
     this.element
@@ -187,7 +187,7 @@ module("Integration | Component | sy timepicker", function(hooks) {
     );
 
     await render(
-      hbs`{{sy-timepicker value=value on-change=(action (mut value))}}`
+      hbs`<SyTimepicker @value={{this.value}} @onChange={{fn (mut this.value)}} />`
     );
 
     this.element
@@ -213,7 +213,7 @@ module("Integration | Component | sy timepicker", function(hooks) {
     );
 
     await render(
-      hbs`{{sy-timepicker value=value on-change=(action (mut value))}}`
+      hbs`<SyTimepicker @value={{this.value}} @onChange={{fn (mut this.value)}} />`
     );
 
     this.element
@@ -239,7 +239,7 @@ module("Integration | Component | sy timepicker", function(hooks) {
     );
 
     await render(
-      hbs`{{sy-timepicker value=value on-change=(action (mut value))}}`
+      hbs`<SyTimepicker @value={{this.value}} @onChange={{fn (mut this.value)}} />`
     );
 
     this.element
@@ -278,7 +278,7 @@ module("Integration | Component | sy timepicker", function(hooks) {
     );
 
     await render(
-      hbs`{{sy-timepicker min=min max=max value=value on-change=(action (mut value))}}`
+      hbs`<SyTimepicker @min={{this.min}} @max={{this.max}} @value={{this.value}} @onChange={{fn (mut this.value)}} />`
     );
 
     this.element
@@ -310,7 +310,7 @@ module("Integration | Component | sy timepicker", function(hooks) {
     );
 
     await render(
-      hbs`{{sy-timepicker precision=5 value=value on-change=(action (mut value))}}`
+      hbs`<SyTimepicker @precision={{5}} @value={{this.value}} @onChange={{fn (mut this.value)}} />`
     );
 
     this.element
@@ -327,7 +327,7 @@ module("Integration | Component | sy timepicker", function(hooks) {
     this.set("value", moment({ h: 12, m: 30 }));
 
     await render(
-      hbs`{{sy-timepicker value=value on-change=(action (mut value))}}`
+      hbs`<SyTimepicker @value={{this.value}} @onChange={{fn (mut this.value)}} />`
     );
 
     await fillIn("input", "");
@@ -340,7 +340,7 @@ module("Integration | Component | sy timepicker", function(hooks) {
     this.set("value", null);
 
     await render(
-      hbs`{{sy-timepicker value=value on-change=(action (mut value))}}`
+      hbs`<SyTimepicker @value={{this.value}} @onChange={{fn (mut this.value)}} />`
     );
 
     this.element
@@ -357,7 +357,7 @@ module("Integration | Component | sy timepicker", function(hooks) {
     this.set("value", null);
 
     await render(
-      hbs`{{sy-timepicker value=value on-change=(action (mut value))}}`
+      hbs`<SyTimepicker @value={{this.value}} @onChange={{fn (mut this.value)}} />`
     );
 
     this.element


### PR DESCRIPTION
## Contents:
Refactor broken date and time pickers and their ocurences on the activity and report view. 
*  6ef87c8 refactor(reports): move action handling to controller
* 95ee1ce fix(activities): prevent unnecessary data fetching
* ad665ad fix(activities): use existing helpers
* 03a3f16 refactor(sy-checkmark): octanify and fix tests
* d756c53 refactor(sy-checkbox): octanify and fix tests
* 799b1ba refactor(sy-durationpicker): rework and fix tests
* edbd2f3 test(sy-timepicker): fix tests after previous octanification
* f72bdfc refactor(activities): rework time and duration pickers

The contents of this PR start at f72bdfc
Commits before belong to #735 

---
## Info 
> 14th PR of [this series](https://github.com/adfinis/timed-frontend/pulls/710) #710.
> **Only merge when #735  is merged and this PR got rebased!**
