### PR TITLE
chore: use pnpm in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,16 @@
-FROM danlynn/ember-cli:latest as build
+FROM danlynn/ember-cli:3.28.0 as build
 
-COPY package.json yarn.lock /myapp/
+RUN npm install -g pnpm
 
-RUN yarn install
+COPY package.json pnpm-lock.yaml /myapp/
+
+RUN pnpm fetch
 
 COPY . /myapp/
 
-RUN yarn build --environment=production
+RUN pnpm install --frozen-lockfile --offline
+
+RUN pnpm run build --environment=production
 
 FROM nginx:alpine
 


### PR DESCRIPTION
Correct me if I'm wrong, but `yarn` shouldn't be used as we switched to `pnpm`.
Not sure if I'm instaling it correctly though.

There's also an option to [fetch](https://pnpm.io/cli/fetch) packages to boost build time. Is this something we could use?