### PR TITLE
ci: upgrade workflow actions to use node 16 by default

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,17 +7,17 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2.0.1
+        uses: pnpm/action-setup@v2.2.4
         with:
-          version: 7.17.1
+          version: ^7.17.1
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "16"
           cache: "pnpm"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        # TODO add hbs
-        target: [js]
+        target: [js, hbs]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,11 @@ name: Test
 
 on:
   push:
-    branches: [$default-branch]
+    branches:
+      - master
   pull_request:
-    branches: [$default-branch]
+    branches:
+      - master
 
 env:
   NODE_VERSION: 16

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Test
 
 on:
   push:
-    branches: [ $default-branch ]
+    branches: [$default-branch]
   pull_request:
-    branches: [ $default-branch ]
+    branches: [$default-branch]
 
 env:
   NODE_VERSION: 16
@@ -21,14 +21,14 @@ jobs:
         target: [js]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2.0.1
+        uses: pnpm/action-setup@v2.2.4
         with:
-          version: 7.17.1
+          version: ^7.17.1
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "pnpm"
@@ -46,14 +46,14 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2.0.1
+        uses: pnpm/action-setup@v2.2.4
         with:
-          version: 7.17.1
+          version: ^7.17.1
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "pnpm"
@@ -70,5 +70,3 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           file: ./coverage/lcov.info
-
-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,6 +68,6 @@ jobs:
           COVERAGE: true
 
       - name: upload coverage report to codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           file: ./coverage/lcov.info

--- a/package.json
+++ b/package.json
@@ -19,9 +19,8 @@
     "lint:js:fix": "eslint --config .eslintrc.js . --fix",
     "prepare": "husky install",
     "preinstall": "npx only-allow pnpm",
-    "lint:js:fix": "eslint . --fix",
     "start": "ember server --proxy http://localhost:8000",
-    "test": "npm-run-all lint test:*",
+    "test": "npm-run-all test:*",
     "test:ember": "ember test"
   },
   "commitlint": {


### PR DESCRIPTION
* Updates all actions to their latest version. This way we get `node 16` by default, still allowing for specific overrides.
* Further it improves the ci workflow by cleaning the `test` script defined in the `package.json`.
* Update and re-enable codecov action. This way future PRs have to at least improve the coverage and we are back in the coverage game. This leads to **failing CI tests for this PR!!** Please ignore the codecov jobs in this PR. The coverage compares with the last available upload which dates back to this commit d45179d.
* The formerly introduced change to the workflow triggers (`$default-branch` in #762 ) got reverted, since this variable is only available in workflow templates.