### PR TITLE
fix(analysis): table sorting according to ordering qp

### DIFF
--- a/app/analysis/edit/controller.js
+++ b/app/analysis/edit/controller.js
@@ -180,7 +180,7 @@ export default class AnalysisEditController extends Controller.extend(
 
       this.router.transitionTo("analysis.index", {
         queryParams: {
-          ...params,
+          ...this.allQueryParams,
         },
       });
 

--- a/app/analysis/edit/controller.js
+++ b/app/analysis/edit/controller.js
@@ -86,14 +86,16 @@ export default class AnalysisEditController extends Controller.extend(
 
   @task
   *intersection() {
-    const res = yield this.fetch.fetch("/api/v1/reports/intersection", {
-      method: "GET",
-      data: {
+    const res = yield this.fetch.fetch(
+      `/api/v1/reports/intersection?${new URLSearchParams({
         ...prepareParams(this.allQueryParams),
         editable: 1,
         include: "task,project,customer,user",
-      },
-    });
+      })}`,
+      {
+        method: "GET",
+      }
+    );
 
     yield this.store.pushPayload("report-intersection", res);
 
@@ -135,8 +137,8 @@ export default class AnalysisEditController extends Controller.extend(
 
   get needsReview() {
     return (
-      this.intersectionModel.review === null ||
-      this.intersectionModel.review === true
+      this.intersectionModel?.review === null ||
+      this.intersectionModel?.review === true
     );
   }
 

--- a/app/analysis/index/controller.js
+++ b/app/analysis/index/controller.js
@@ -108,19 +108,12 @@ export const AnalysisQueryParams = new QueryParams({
     replace: true,
     refresh: true,
   },
-  // We serialize the ordering as null if the
-  // value equals the defaultValue. For some reason
-  // if the serialized value is not null we had some
-  // weird query param behavior where the ordering
-  // param was set to the defaultValue when editing
-  // a report and due to that all other queryParams
-  // where reset.
   ordering: {
     defaultValue: "-date",
     replace: true,
     refresh: true,
     serialize(val) {
-      return val?.endsWith(",id") ? val : `${val},id`;
+      return `${val},id`;
     },
     deserialize(val) {
       return val.replace(",id", "");
@@ -132,7 +125,6 @@ export default class AnalysisController extends Controller.extend(
   AnalysisQueryParams.Mixin
 ) {
   exportLinks = config.APP.REPORTEXPORTS;
-
   exportLimit = config.APP.EXPORT_LIMIT;
 
   @service session;

--- a/app/analysis/index/controller.js
+++ b/app/analysis/index/controller.js
@@ -120,10 +120,10 @@ export const AnalysisQueryParams = new QueryParams({
     replace: true,
     refresh: true,
     serialize(val) {
-      return val === "-date" ? null : `${val},id`;
+      return val?.endsWith(",id") ? val : `${val},id`;
     },
     deserialize(val) {
-      return val === null ? "-date" : val.replace(",id", "");
+      return val.replace(",id", "");
     },
   },
 });

--- a/app/protected/route.js
+++ b/app/protected/route.js
@@ -29,12 +29,14 @@ export default class ProtectedRoute extends Route {
   }
 
   async model() {
-    const user = await this.fetch.fetch("/api/v1/users/me", {
-      method: "GET",
-      data: {
+    const user = await this.fetch.fetch(
+      `/api/v1/users/me?${new URLSearchParams({
         include: "supervisors,supervisees",
-      },
-    });
+      })}`,
+      {
+        method: "GET",
+      }
+    );
 
     await this.store.pushPayload("user", user);
 

--- a/app/services/fetch.js
+++ b/app/services/fetch.js
@@ -47,7 +47,7 @@ export default class FetchService extends Service {
       ...(init.headers || {}),
     });
 
-    if (init?.method === "POST" || init?.method === "PATCH") {
+    if (init?.method !== "GET" && init?.method !== "HEAD") {
       init.body = stringifyBodyData(init);
     }
 
@@ -74,6 +74,11 @@ export default class FetchService extends Service {
           `Fetch request to URL ${response.url} returned ${response.status} ${response.statusText}:\n\n${body}`
         ),
       };
+    }
+    // Return early when "No Content" response is given. Trying to parse JSON
+    // from that would result in an error.
+    if (response.status === 204) {
+      return await response.text();
     }
 
     return await response.json();

--- a/app/services/fetch.js
+++ b/app/services/fetch.js
@@ -47,7 +47,7 @@ export default class FetchService extends Service {
       ...(init.headers || {}),
     });
 
-    if (init?.method !== "GET" && init?.method !== "HEAD") {
+    if (!!init?.method && init?.method !== "GET" && init?.method !== "HEAD") {
       init.body = stringifyBodyData(init);
     }
 
@@ -78,6 +78,7 @@ export default class FetchService extends Service {
     // Return early when "No Content" response is given. Trying to parse JSON
     // from that would result in an error.
     if (response.status === 204) {
+      /* istanbul ignore next */
       return await response.text();
     }
 

--- a/tests/acceptance/analysis-edit-test.js
+++ b/tests/acceptance/analysis-edit-test.js
@@ -60,7 +60,7 @@ module("Acceptance | analysis edit", function (hooks) {
 
     assert.deepEqual(Object.keys(relationships), []);
 
-    assert.strictEqual(currentURL(), "/analysis");
+    assert.strictEqual(currentURL(), "/analysis?ordering=-date%2Cid");
   });
 
   test("can cancel", async function (assert) {
@@ -68,7 +68,7 @@ module("Acceptance | analysis edit", function (hooks) {
 
     await click("[data-test-cancel]");
 
-    assert.strictEqual(currentURL(), "/analysis");
+    assert.strictEqual(currentURL(), "/analysis?ordering=-date%2Cid");
   });
 
   test("can reset", async function (assert) {

--- a/tests/acceptance/analysis-test.js
+++ b/tests/acceptance/analysis-test.js
@@ -181,7 +181,7 @@ module("Acceptance | analysis", function (hooks) {
 
     await click("[data-test-edit-all]");
 
-    assert.equal(currentURL(), "/analysis/edit?editable=1");
+    assert.equal(currentURL(), "/analysis/edit?editable=1&ordering=-date%2Cid");
   });
 
   test("can edit selected reports", async function (assert) {


### PR DESCRIPTION
## Problem
Sorting the analysis table via clicking on the `Date` header does not trigger the ordering change.

## Solution
Do not serialize the `ordering` QP to `null`, if it's equal to the default value (`-date,id`)

## Background 
When entering `/analysis` the default query parameter for `ordering` should be `-date` which results in a serialized `-date,id` QP. As long as the QP is equal to it's default value, it should not occur in the URL. So far so good. 

But somehow, the QP will be present in the URL event though it's equal to the default value in the acceptance tests for `Acceptance | analysis edit: can edit`. :( 
Ergo we have to adapt the test-assertion or tune the QP more. What do you think @velrest ?