### PR TITLE
fix(sy-durationpicker): create duration if none is passed

### DIFF
--- a/app/components/sy-durationpicker/component.js
+++ b/app/components/sy-durationpicker/component.js
@@ -70,6 +70,13 @@ export default class SyDurationpicker extends SyTimepickerComponent {
   }
 
   /**
+   * Unwraps the passed value or creates a fresh duration object.
+   */
+  get value() {
+    return this.optionalUnwrap(this.args.value) ?? moment.duration();
+  }
+
+  /**
    * Set the current value
    *
    * @method _set


### PR DESCRIPTION
As this component extends the `sy-timepicker` component, we have to override the `value` getter, which would otherwise initiate a `moment` object instead of a `moment.duration` for the duration picker, which leads to wild behavior of the component.