### PR TITLE
fix(analysis): show number of displayed reports

### DIFF
--- a/app/analysis/index/controller.js
+++ b/app/analysis/index/controller.js
@@ -137,6 +137,8 @@ export default class AnalysisController extends Controller.extend(
   @tracked _shouldLoadMore = false;
   @tracked _canLoadMore = true;
   @tracked _lastPage = 0;
+  @tracked totalTime = moment.duration();
+  @tracked totalItems = A();
   @tracked selectedReportIds;
 
   @tracked user;
@@ -207,6 +209,8 @@ export default class AnalysisController extends Controller.extend(
     this._shouldLoadMore = false;
     this._dataCache = A();
     this.selectedReportIds = A();
+    this.totalTime = moment.duration();
+    this.totalItems = A();
 
     this.data.perform();
   }

--- a/app/analysis/index/template.hbs
+++ b/app/analysis/index/template.hbs
@@ -397,7 +397,7 @@
                         false
                       }}</strong></td>
                   <td colspan="6" class="text-right"><em>Displaying
-                      {{this.reports.length}}
+                      {{reports.length}}
                       of
                       {{this.totalItems}}
                       reports</em></td>
@@ -431,10 +431,7 @@
                   disabled={{this.exportLimitExceeded}}
                   title={{if this.exportLimitExceeded this.exportLimitMessage}}
                 >
-                  <FaIcon
-                    @icon="download"
-                    @prefix="fas"
-                  />&nbsp;{{link.label}}
+                  <FaIcon @icon="download" @prefix="fas" />&nbsp;{{link.label}}
                 </button>
               {{/each}}
             </div>


### PR DESCRIPTION
Fixes #727 

* makes `totalTime` and `totalItems` a tracked property, otherwise updates of the template were unpredictable
* uses the correct `reports` reference in the template