### PR TITLE
ci: update github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "00:00"
-  open-pull-requests-limit: 10

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -1,4 +1,4 @@
-name: Release Container Image
+name: Release ghcr image
 
 on:
   push:
@@ -37,7 +37,7 @@ jobs:
 
       - name: Build and push
         id: docker_build_ghcr
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           file: ./Dockerfile


### PR DESCRIPTION
* update github action, which upgrades internally to node ~~12~~ 16
* remove dependabot config since [we are using renovate now](https://github.com/adfinis/timed-frontend/pull/779)