### PR TITLE
fix(statistic-list-bar): improve bar graph representation

### DIFF
--- a/app/components/statistic-list/bar/template.hbs
+++ b/app/components/statistic-list/bar/template.hbs
@@ -5,13 +5,15 @@
     class="statistic-list-bar"
     {{style --value=(concat @value)}}
   ></div>
-  {{#if @remaining}}
+  {{#if (and @remaining (lt @remaining 1))}}
     <div
       ...attributes
       class="statistic-list-bar remaining
         {{if (gt @remaining @goal) 'danger' 'success'}}"
       {{style --value=(concat @remaining)}}
     ></div>
+  {{/if}}
+  {{#if @goal}}
     <div
       ...attributes
       class="statistic-list-bar-goal"

--- a/app/components/statistic-list/template.hbs
+++ b/app/components/statistic-list/template.hbs
@@ -73,8 +73,8 @@
               as |allotted|
             }}
               <StatisticList::Bar
-                @value={{(div row.duration this.maxDuration)}}
-                @remaining={{(div allotted this.maxDuration)}}
+                @value={{div row.duration this.maxDuration}}
+                @remaining={{div allotted this.maxDuration}}
                 @goal={{min "0.99" (div row.estimatedTime this.maxDuration)}}
               />
             {{/let}}

--- a/app/models/task-statistic.js
+++ b/app/models/task-statistic.js
@@ -1,11 +1,9 @@
 import Model, { attr, belongsTo } from "@ember-data/model";
-import moment from "moment";
 
 export default class TaskStatistics extends Model {
   @attr name;
   @attr("django-duration") duration;
-  @attr("django-duration", { defaultValue: () => moment.duration() })
-  estimatedTime;
+  @attr("django-duration") estimatedTime;
   @attr("django-duration") mostRecentRemainingEffort;
   @belongsTo("project") project;
 }


### PR DESCRIPTION
**Follow up after #721**
The bar chart would show the goal and remaining effort even if it's not defined/enabled on the task/project, like shown in the screenshot. This behavior is not intended and the red dotted "goal line" should not be visible if no estimed time is given. 

![image](https://user-images.githubusercontent.com/10029904/214608737-0e89061a-51c2-4124-b997-e47cf0343d8b.png)

