### PR TITLE
chore(test-workflow): add renovate branches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - renovate/**
   pull_request:
     branches:
       - master


### PR DESCRIPTION
Branches opened by renovate need to run through the test workflows before automerge can proceed.

This [configuration is endorsed by renovate](https://docs.renovatebot.com/key-concepts/automerge/#branch-vs-pr-automerging).