### PR TITLE
fix(customer-statistics): require fromDate param

### DIFF
--- a/app/statistics/controller.js
+++ b/app/statistics/controller.js
@@ -20,7 +20,7 @@ const deserializeMoment = (momentString) =>
 const TYPES = {
   year: { include: "", requiredParams: [] },
   month: { include: "", requiredParams: [] },
-  customer: { include: "", requiredParams: [] },
+  customer: { include: "", requiredParams: ["fromDate"] },
   project: {
     include: "customer",
     requiredParams: ["customer"],

--- a/tests/acceptance/statistics-test.js
+++ b/tests/acceptance/statistics-test.js
@@ -40,7 +40,7 @@ module("Acceptance | statistics", function (hooks) {
   });
 
   test("can view statistics by customer", async function (assert) {
-    await visit("/statistics?type=customer");
+    await visit("/statistics?type=customer&fromDate=1900-01-01");
 
     assert.dom("thead > tr > th").exists({ count: 3 });
     assert.dom("tbody > tr").exists({ count: 5 });


### PR DESCRIPTION
The customer-statistics request is quite demanding to for the backend. Especially on our test instance with only one pod this leads to very long waiting times or crashes of the backend. That's why we want to make the `fromDate` query param required for the customer statistics view.