### PR TITLE
fix(reports): check if reports got verified before transfer

### DIFF
--- a/app/index/reports/controller.js
+++ b/app/index/reports/controller.js
@@ -140,7 +140,19 @@ export default class IndexReportController extends Controller {
   @action
   async reschedule(date) {
     try {
-      const reports = this.reports.filterBy("isNew", false);
+      const reports = this.reports
+        .filterBy("isNew", false)
+        .rejectBy("verifiedBy.id");
+
+      // The magic number "-1" is the placeholder report row which we filter out
+      // via the filterBy("isNew") line above.
+      if (reports.length < this.reports.length - 1) {
+        /* istanbul ignore next */
+        this.notify.warning(
+          "Reports that got verified already can not get transferred."
+        );
+      }
+
       await all(
         reports.map(async (report) => {
           report.set("date", date);


### PR DESCRIPTION
This prevents *already verified* reports from being *temporarily* (namely until the next hard refresh) to be transferred, although they can not get transferred when verified.

Includes a verbose warning message for the user. => UX :one: :up: 

Fixes #807 