### PR TITLE
fix(remaining-effort): display validation errors in project view

### DIFF
--- a/app/projects/template.hbs
+++ b/app/projects/template.hbs
@@ -65,10 +65,18 @@
         {{/if}}
 
         <div class="btn-toolbar btn-toolbar--right">
+          {{#each f.model.errors as |error|}}
+            <div class="validation-error-icon" title={{error.validation}}>
+              <FaIcon @icon="exclamation-triangle" @prefix="fas" />
+            </div>
+          {{/each}}
+
           <f.submit
             data-test-project-save
             @disabled={{f.model.isInvalid}}
-          >Update</f.submit>
+            @triggerValidations={{true}}
+          >Update
+          </f.submit>
         </div>
       </ValidatedForm>
 

--- a/app/styles/projects.scss
+++ b/app/styles/projects.scss
@@ -119,3 +119,8 @@
     width: 20%;
   }
 }
+
+.validation-error-icon {
+  margin: auto 0.5rem;
+  color: $color-warning;
+}


### PR DESCRIPTION
We still need the `billingType` valdations for patches on the `projects` endpoint. To show the users they can't update the project (toggle remaining effort tracking checkbox), we show a warning icon with the error as hover description. See attached screenshot for final UI.

*warning icon on projects page*
![error](https://user-images.githubusercontent.com/10029904/219062754-c71b8fff-41c8-4835-a755-2229f05c5c75.png)

*warning icon hovered*
![error_title](https://user-images.githubusercontent.com/10029904/219062753-ebda77d2-391d-4dab-af72-62c0d0e982d1.png)


