### PR TITLE
feat(remaining-effort): add re feature to project statistics

### DIFF
--- a/app/components/statistic-list/bar/template.hbs
+++ b/app/components/statistic-list/bar/template.hbs
@@ -5,7 +5,7 @@
     class="statistic-list-bar"
     {{style --value=(concat @value)}}
   ></div>
-  {{#if (and @remaining (lt @remaining 1))}}
+  {{#if (and @remaining (lte @remaining 1))}}
     <div
       ...attributes
       class="statistic-list-bar remaining
@@ -17,7 +17,7 @@
     <div
       ...attributes
       class="statistic-list-bar-goal"
-      {{style --goal=(concat @goal)}}
+      {{style --goal=(concat (min "0.99" @goal))}}
     ></div>
   {{/if}}
 </div>

--- a/app/components/statistic-list/component.js
+++ b/app/components/statistic-list/component.js
@@ -31,6 +31,11 @@ const COLUMN_MAP = {
       layout: DURATION_LAYOUT,
     },
     { title: "Duration", path: "duration", layout: DURATION_LAYOUT },
+    {
+      title: "Remaining Effort",
+      path: "totalRemainingEffort",
+      layout: DURATION_LAYOUT,
+    },
   ],
   task: [
     {

--- a/app/components/statistic-list/template.hbs
+++ b/app/components/statistic-list/template.hbs
@@ -69,7 +69,10 @@
           {{/each}}
           <td>
             {{#let
-              (add row.duration row.mostRecentRemainingEffort)
+              (add
+                row.duration
+                (or row.totalRemainingEffort row.mostRecentRemainingEffort)
+              )
               as |allotted|
             }}
               <StatisticList::Bar

--- a/app/components/statistic-list/template.hbs
+++ b/app/components/statistic-list/template.hbs
@@ -69,17 +69,19 @@
           {{/each}}
           <td>
             {{#let
-              (add
-                row.duration
-                (or row.totalRemainingEffort row.mostRecentRemainingEffort)
-              )
-              as |allotted|
+              (or row.totalRemainingEffort row.mostRecentRemainingEffort)
+              as |remainingEffort|
             }}
-              <StatisticList::Bar
-                @value={{div row.duration this.maxDuration}}
-                @remaining={{div allotted this.maxDuration}}
-                @goal={{min "0.99" (div row.estimatedTime this.maxDuration)}}
-              />
+              {{#let
+                (if remainingEffort (add row.duration remainingEffort) 0)
+                as |allotted|
+              }}
+                <StatisticList::Bar
+                  @value={{div row.duration this.maxDuration}}
+                  @remaining={{div allotted this.maxDuration}}
+                  @goal={{div row.estimatedTime this.maxDuration}}
+                />
+              {{/let}}
             {{/let}}
           </td>
         </tr>

--- a/tests/acceptance/statistics-test.js
+++ b/tests/acceptance/statistics-test.js
@@ -50,7 +50,7 @@ module("Acceptance | statistics", function (hooks) {
   test("can view statistics by project", async function (assert) {
     await visit("/statistics?type=project&customer=1");
 
-    assert.dom("thead > tr > th").exists({ count: 5 });
+    assert.dom("thead > tr > th").exists({ count: 6 });
     assert.dom("tbody > tr").exists({ count: 5 });
     assert.dom("tfoot").includesText("Total");
   });


### PR DESCRIPTION
## Description
Adds the remaining-effort feature to the *by project* tab of the statistics page. Lately we added it only to *by task* tab.

## Preview
![image](https://user-images.githubusercontent.com/10029904/219323131-8d4f2527-cb95-4a60-9e80-d6ee49e1b561.png)
