### PR TITLE
fix(tracking-service): replace drop task modifier

### DIFF
--- a/app/components/report-row/component.js
+++ b/app/components/report-row/component.js
@@ -1,28 +1,12 @@
-/**
- * @module timed
- * @submodule timed-components
- * @public
- */
-
 import { action } from "@ember/object";
 import { inject as service } from "@ember/service";
 import Component from "@glimmer/component";
-import { tracked } from "@glimmer/tracking";
 import ReportValidations from "timed/validations/report";
 
-/**
- * Component for the editable report row
- *
- * @class ReportRowComponent
- * @extends Ember.Component
- * @public
- */
 export default class ReportRowComponent extends Component {
   @service abilities;
 
   ReportValidations = ReportValidations;
-
-  @tracked task;
 
   get editable() {
     return this.abilities.can("edit report", this.args.report);


### PR DESCRIPTION
The `dropTask` modifier prevented multiple instances of the `TaskSelect` component in the timesheet overview from fetching their data for the dropdown. With the renewed logic, it will prevent fetching the same query multiple times.