### PR TITLE
chore: bump displayed version to 3.0.0-rc

### DIFF
--- a/app/components/sy-topnav/template.hbs
+++ b/app/components/sy-topnav/template.hbs
@@ -12,7 +12,7 @@
       <div class="nav-top-header-title">
         Timed
         <div class="nav-top-header-title-version">
-          v{{app-version hideSha=true}}
+          v{{app-version versionOnly=true showExtended=true}}
         </div>
       </div>
     </LinkTo>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "timed",
-  "version": "2.1.3",
+  "version": "3.0.0-rc.12",
   "private": true,
   "description": "A time tracking software written in Ember.js",
   "repository": "https://github.com/adfinis-sygroup/timed-frontend",


### PR DESCRIPTION
Fixes #825 

`pre-releases` do not trigger semantic-release normally, so we have to bump it manually for now.

We'll investigate if we could leverage the `semantic-release` package also for the `pre-release` trigger.

See the [ember-cli-app-version docu](https://github.com/ember-cli/ember-cli-app-version#app-version-helper) for convenience.