### PR TITLE
fix(reject-report): delete date restriction for rejected reports

### DIFF
--- a/app/components/report-review-warning/template.hbs
+++ b/app/components/report-review-warning/template.hbs
@@ -30,7 +30,7 @@
         @route="analysis.index"
         @query={{hash
           fromDate=null
-          toDate=this.unverifiedReports.reportsToDate
+          toDate=null
           user=this.session.data.user.id
           editable=1
           rejected=1

--- a/app/services/rejected-reports.js
+++ b/app/services/rejected-reports.js
@@ -1,7 +1,6 @@
 import Service, { inject as service } from "@ember/service";
 import { macroCondition, isTesting } from "@embroider/macros";
 import { tracked } from "@glimmer/tracking";
-import moment from "moment";
 
 const INTERVAL_DELAY = 10 * 60000; // 10 Minutes
 
@@ -20,10 +19,6 @@ export default class RejectedReportsService extends Service {
 
   get hasReports() {
     return this.amountReports > 0;
-  }
-
-  get reportsToDate() {
-    return moment().subtract(1, "month").endOf("month");
   }
 
   constructor(...args) {


### PR DESCRIPTION
Hitting the rejected-reports link in the nav still navigated to the reports page with a `toDate` filter set. This is not intended since we want to see all the rejected reports.