### PR TITLE
fix(task-selection): respect archived filter

### DIFF
--- a/app/components/task-selection/component.js
+++ b/app/components/task-selection/component.js
@@ -204,13 +204,11 @@ export default class TaskSelectionComponent extends Component {
 
     const customers = this.store
       .peekAll("customer")
-      .filter((customer) => {
-        return this.archived ? true : !customer.archived;
-      })
+      ?.filter(this.filterByArchived)
       .sortBy("name");
 
     const tasks = this.store.peekAll("task").filter((task) => {
-      return ids.includes(task.id) && (this.archived ? true : !task.archived);
+      return ids.includes(task.id) && this.filterByArchived(task);
     });
 
     return [...tasks.toArray(), ...customers.toArray()];
@@ -224,6 +222,22 @@ export default class TaskSelectionComponent extends Component {
 
   get customersAndRecentTasks() {
     return this._customersAndRecentTasks.value ?? [];
+  }
+
+  get projects() {
+    return this.customer?.projects
+      ?.filter(this.filterByArchived)
+      .sortBy("name");
+  }
+
+  get tasks() {
+    return this.project?.tasks?.filter(this.filterByArchived).sortBy("name");
+  }
+
+  @action
+  filterByArchived(filterable) {
+    //using the action decorator to bind the context for this
+    return this.archived ? true : !filterable?.archived;
   }
 
   /**

--- a/app/components/task-selection/template.hbs
+++ b/app/components/task-selection/template.hbs
@@ -18,7 +18,7 @@
     )
     project=(component
       (ensure-safe-component "optimized-power-select")
-      options=this.customer.projects
+      options=this.projects
       disabled=(or @disabled (not this.customer))
       selected=this.project
       placeholder="Select project..."
@@ -34,7 +34,7 @@
     )
     task=(component
       (ensure-safe-component "optimized-power-select")
-      options=this.project.tasks
+      options=this.tasks
       disabled=(or @disabled (not this.project))
       selected=this.task
       placeholder="Select task..."


### PR DESCRIPTION
Fixes #838 and #839 

The previously refactored task-selection component, did not filter the respective projects and tasks for their current `archived` status. This yielded way more results in the dropdown as expect. Further those results where not ordered and that's why it seemed like it shows some *recent projects / tasks* which in reality, where just the first entries which got previously fetched to the store by other components of the app (e.g. timesheet).