### PR TITLE
fix(projects): enable search in customer and project selects

### DIFF
--- a/app/projects/controller.js
+++ b/app/projects/controller.js
@@ -118,11 +118,16 @@ export default class ProjectsController extends Controller {
 
   @action
   handleCustomerChange(customer) {
-    this.selectedCustomer = customer;
+    // If customer is null, we return a Promise. EPS has a bug, where promise
+    // based selections can not get reset with a non-promise value.
+    // See: https://github.com/cibernox/ember-power-select/issues/1467
+    this.selectedCustomer = customer ?? Promise.resolve();
     this.selectedProject = null;
     this.selectedTask = null;
 
-    this.filterProjects.perform();
+    if (this.selectedCustomer !== null) {
+      this.filterProjects.perform();
+    }
   }
 
   @action

--- a/app/projects/template.hbs
+++ b/app/projects/template.hbs
@@ -11,6 +11,7 @@
         class="header-item"
         @options={{this.customers}}
         @placeholder="Select customer..."
+        @searchEnabled={{true}}
         @searchField="name"
         @onChange={{this.handleCustomerChange}}
         @selected={{this.selectedCustomer}}
@@ -25,6 +26,7 @@
         class="header-item"
         @options={{this.filteredProjects}}
         placeholder="Select project..."
+        @searchEnabled={{true}}
         @searchField="name"
         @onChange={{this.handleProjectChange}}
         @selected={{this.selectedProject}}


### PR DESCRIPTION
Further fix a bug where one could not reset the customer select.

This fixes a bug report from @anehx who was missing the search functionality on the project page' selects.
