### PR TITLE
fix(task-selection): fill selects with available entries

### DIFF
--- a/app/components/task-selection/component.js
+++ b/app/components/task-selection/component.js
@@ -49,6 +49,8 @@ export default class TaskSelectionComponent extends Component {
       this.onProjectChange(project);
     } else if (customer && !this.customer) {
       this.onCustomerChange(customer);
+    } else {
+      this.tracking.fetchCustomers.perform();
     }
   }
 

--- a/app/components/task-selection/component.js
+++ b/app/components/task-selection/component.js
@@ -268,10 +268,9 @@ export default class TaskSelectionComponent extends Component {
     if (value && value.get("constructor.modelName") === "task") {
       this._customer = await value.get("project.customer");
       this.onTaskChange(value);
-      return;
+    } else {
+      this._customer = value;
     }
-
-    this._customer = value;
 
     if (this.customer?.id) {
       this.tracking.projects.perform(this.customer.id);

--- a/config/icons.js
+++ b/config/icons.js
@@ -2,6 +2,7 @@ module.exports = function () {
   return {
     "free-regular-svg-icons": [
       "calendar",
+      "calendar-plus",
       "calendar-xmark",
       "chart-bar",
       "clock",

--- a/tests/integration/components/tracking-bar/component-test.js
+++ b/tests/integration/components/tracking-bar/component-test.js
@@ -11,7 +11,10 @@ module("Integration | Component | tracking bar", function (hooks) {
     setupTrackingService(this, {
       activity: { comment: "asdf" },
       fetchRecentTasks: { last: Promise.resolve() },
-      fetchCustomers: { last: Promise.resolve() },
+      fetchCustomers: {
+        perform: () => {},
+        last: Promise.resolve(),
+      },
     });
   });
 


### PR DESCRIPTION
Fixes #852 

When selecting a *recent task* (history) then we still need to load all available projects for the indirect selected customer. Otherwise the list of projects will be incomplete.