### PR TITLE
fix: adding or editing tasks on projects page

### DIFF
--- a/app/components/progress-tooltip/component.js
+++ b/app/components/progress-tooltip/component.js
@@ -46,17 +46,22 @@ export default class ProgressTooltipComponent extends Component {
 
   get remainingEffort() {
     const model = this.args.model;
-    const isProjectWithEnabledTracking =
-      model.constructor.modelName === "project" &&
-      model.remainingEffortTracking;
+    const isProject = model.constructor.modelName === "project";
+    const hasRemainingEffortTracking = isProject
+      ? model.remainingEffortTracking
+      : model.get("project.remainingEffortTracking");
+
+    if (!hasRemainingEffortTracking) {
+      return null;
+    }
 
     if (macroCondition(isTesting())) {
-      return isProjectWithEnabledTracking
+      return isProject
         ? model.totalRemainingEffort
         : model.mostRecentRemainingEffort;
     }
 
-    return isProjectWithEnabledTracking
+    return isProject
       ? this.totalRemainingEffort
       : this.mostRecentRemainingEffort;
   }

--- a/app/components/sy-durationpicker/component.js
+++ b/app/components/sy-durationpicker/component.js
@@ -115,7 +115,7 @@ export default class SyDurationpicker extends SyTimepickerComponent {
   }
 
   _isValid(duration) {
-    return duration < this.max && duration > this.min;
+    return duration <= this.max && duration >= this.min;
   }
 
   @action

--- a/app/projects/controller.js
+++ b/app/projects/controller.js
@@ -142,7 +142,10 @@ export default class ProjectsController extends Controller {
 
   @action
   updateRemainingEffort(changeset) {
-    if (!changeset.get("mostRecentRemainingEffort")) {
+    if (
+      changeset.get("project.remainingEffortTracking") &&
+      !changeset.get("mostRecentRemainingEffort")
+    ) {
       changeset.set(
         "mostRecentRemainingEffort",
         changeset.get("estimatedTime")

--- a/app/projects/template.hbs
+++ b/app/projects/template.hbs
@@ -38,192 +38,222 @@
       </PowerSelect>
     </div>
     {{#if this.selectedProject}}
-      <h2>
-        <span class="header-left">
-          {{this.selectedProject.name}}
-        </span>
-      </h2>
-      <ValidatedForm
-        @model={{changeset this.selectedProject this.projectValidations}}
-        @on-submit={{perform this.saveProject}}
-        as |f|
-      >
-        <f.input @name="remainingEffortTracking" as |fi|>
-          <SyCheckbox
-            data-test-remaing-effort-tracking
-            @checked={{this.selectedProject.remainingEffortTracking}}
-            @value={{fi.value}}
-            @onChange={{fi.update}}
-          >Remaining Effort Tracking</SyCheckbox>
-        </f.input>
-        {{#if
-          (and
-            this.selectedProject.remainingEffortTracking
-            this.selectedProject.totalRemainingEffort
-          )
-        }}
-          Total remaing effort:
-          {{humanize-duration this.selectedProject.totalRemainingEffort}}
-        {{/if}}
+      {{#let
+        this.selectedProject.remainingEffortTracking
+        as |remainingEffortTracking|
+      }}
+        <h2>
+          <span class="header-left">
+            {{this.selectedProject.name}}
+          </span>
+        </h2>
+        <ValidatedForm
+          @model={{changeset this.selectedProject this.projectValidations}}
+          @on-submit={{perform this.saveProject}}
+          as |f|
+        >
+          <f.input @name="remainingEffortTracking" as |fi|>
+            <SyCheckbox
+              data-test-remaing-effort-tracking
+              @checked={{remainingEffortTracking}}
+              @value={{fi.value}}
+              @onChange={{fi.update}}
+            >Remaining Effort Tracking</SyCheckbox>
+          </f.input>
+          {{#if
+            (and
+              remainingEffortTracking this.selectedProject.totalRemainingEffort
+            )
+          }}
+            Total remaing effort:
+            {{humanize-duration this.selectedProject.totalRemainingEffort}}
+          {{/if}}
 
-        <div class="btn-toolbar btn-toolbar--right">
-          {{#each f.model.errors as |error|}}
-            <div class="validation-error-icon" title={{error.validation}}>
-              <FaIcon @icon="exclamation-triangle" @prefix="fas" />
-            </div>
-          {{/each}}
-
-          <f.submit
-            data-test-project-save
-            @disabled={{f.model.isInvalid}}
-            @triggerValidations={{true}}
-          >Update
-          </f.submit>
-        </div>
-      </ValidatedForm>
-
-      <hr />
-      <h3>
-        <span class="header-left">
-          Tasks
-        </span>
-        <span class="header-right">
-          <button
-            class="btn btn-primary"
-            data-test-add-task
-            type="button"
-            {{on "click" (perform this.createTask)}}
-          >Add Task</button>
-        </span>
-      </h3>
-      <div class="task-table-container">
-        <EmberScrollable @class="projects-scrollable-container">
-          <table
-            class="table table--striped table--projects"
-            data-test-tasks-table
-          >
-            <thead>
-              <tr>
-                <th>Name</th>
-                <th>Reference</th>
-                <th>Estimated time</th>
-                <th>Archived</th>
-              </tr>
-            </thead>
-            <tbody>
-              {{#each this.tasks as |task|}}
-                <tr
-                  class="pointer {{if (eq this.selectedTask task) 'selected'}}"
-                  {{! template-lint-disable }}
-                  {{on "click" (fn (mut this.selectedTask) task)}}
-                  data-test-task-table-row
-                >
-                  <td data-test-table-name>{{task.name}}</td>
-                  <td data-test-table-reference>{{if
-                      task.reference
-                      task.reference
-                      "-"
-                    }}</td>
-                  <td data-test-table-estimated-time>{{if
-                      task.estimatedTime
-                      (humanize-duration task.estimatedTime)
-                      "-"
-                    }}</td>
-                  <td><SyCheckmark
-                      data-test-table-archived
-                      @checked={{task.archived}}
-                    /></td>
-                </tr>
-              {{/each}}
-            </tbody>
-          </table>
-        </EmberScrollable>
-      </div>
-      {{#if this.selectedTask}}
-        <div class="task-form-container" data-test-task-form>
-          <h3>{{if
-              this.selectedTask.isNew
-              "Add task"
-              this.selectedTask.name
-            }}</h3>
-          <ValidatedForm
-            @model={{changeset this.selectedTask this.taskValidations}}
-            @on-submit={{perform this.saveTask}}
-            as |f|
-          >
-            <div class="task-form-container-row">
-              <div class="task-form-container-column">
-                <f.input
-                  @label="Name"
-                  @name="name"
-                  data-test-name
-                  @required={{true}}
-                />
-                <f.input
-                  @label="Reference"
-                  @name="reference"
-                  data-test-reference
-                  @required={{false}}
-                />
+          <div class="btn-toolbar btn-toolbar--right">
+            {{#each f.model.errors as |error|}}
+              <div class="validation-error-icon" title={{error.validation}}>
+                <FaIcon @icon="exclamation-triangle" @prefix="fas" />
               </div>
-              <div class="task-form-container-column">
-                <f.input @name="estimatedTime" as |fi|>
-                  <div class="form-group">
-                    <label>
-                      Estimated time
-                    </label>
-                    <SyDurationpicker
-                      data-test-estimated-time={{true}}
-                      @value={{fi.value}}
-                      @onChange={{(queue
-                        fi.update (fn this.updateRemainingEffort f.model)
-                      )}}
-                    />
-                  </div>
-                </f.input>
+            {{/each}}
 
-                {{#if this.selectedProject.remainingEffortTracking}}
-                  <f.input @name="mostRecentRemainingEffort" as |fi|>
+            <f.submit
+              data-test-project-save
+              @disabled={{f.model.isInvalid}}
+              @triggerValidations={{true}}
+            >Update
+            </f.submit>
+          </div>
+        </ValidatedForm>
+
+        <hr />
+        <h3>
+          <span class="header-left">
+            Tasks
+          </span>
+          <span class="header-right">
+            <button
+              class="btn btn-primary"
+              data-test-add-task
+              type="button"
+              {{on "click" (perform this.createTask)}}
+            >Add Task</button>
+          </span>
+        </h3>
+        <div class="task-table-container">
+          <EmberScrollable @class="projects-scrollable-container">
+            <table
+              class="table table--striped table--projects"
+              data-test-tasks-table
+            >
+              <colgroup>
+                <col class="title" />
+                <col class="reference" />
+                <col class="duration" />
+                {{#if remainingEffortTracking}}
+                  <col class="duration" />
+                {{/if}}
+                <col class="archived" />
+              </colgroup>
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Reference</th>
+                  <th>Estimated time</th>
+                  {{#if remainingEffortTracking}}
+                    <th>Remaining effort</th>
+                  {{/if}}
+                  <th>Archived</th>
+                </tr>
+              </thead>
+              <tbody>
+                {{#each this.tasks as |task|}}
+                  <tr
+                    class="pointer
+                      {{if (eq this.selectedTask task) 'selected'}}"
+                    {{! template-lint-disable }}
+                    {{on "click" (fn (mut this.selectedTask) task)}}
+                    data-test-task-table-row
+                  >
+                    <td data-test-table-name>{{task.name}}</td>
+                    <td data-test-table-reference>{{if
+                        task.reference
+                        task.reference
+                        "-"
+                      }}</td>
+                    <td data-test-table-estimated-time>{{if
+                        task.estimatedTime
+                        (humanize-duration task.estimatedTime)
+                        "-"
+                      }}</td>
+
+                    {{#if remainingEffortTracking}}
+                      <td data-test-table-most-recent-remaining-effort>{{if
+                          task.mostRecentRemainingEffort
+                          (humanize-duration task.mostRecentRemainingEffort)
+                          "-"
+                        }}</td>
+                    {{/if}}
+                    <td><SyCheckmark
+                        data-test-table-archived
+                        @checked={{task.archived}}
+                      /></td>
+                  </tr>
+                {{/each}}
+              </tbody>
+            </table>
+          </EmberScrollable>
+        </div>
+        {{#if this.selectedTask}}
+          <div class="task-form-container" data-test-task-form>
+            <h3>{{if
+                this.selectedTask.isNew
+                "Add task"
+                this.selectedTask.name
+              }}</h3>
+            <ValidatedForm
+              @model={{changeset this.selectedTask this.taskValidations}}
+              @on-submit={{perform this.saveTask}}
+              as |f|
+            >
+              <div class="task-form-container-row">
+                <div class="task-form-container-column">
+                  <f.input
+                    @label="Name"
+                    @name="name"
+                    data-test-name
+                    @required={{true}}
+                  />
+                  <f.input
+                    @label="Reference"
+                    @name="reference"
+                    data-test-reference
+                    @required={{false}}
+                  />
+                </div>
+                <div class="task-form-container-column">
+                  <f.input @name="estimatedTime" as |fi|>
                     <div class="form-group">
                       <label>
-                        Remaing effort
+                        Estimated time
                       </label>
                       <SyDurationpicker
-                        data-test-remaining-effort={{true}}
+                        data-test-estimated-time={{true}}
+                        @value={{fi.value}}
+                        @onChange={{(if
+                          remainingEffortTracking
+                          (queue
+                            fi.update (fn this.updateRemainingEffort f.model)
+                          )
+                          fi.update
+                        )}}
+                      />
+                    </div>
+                  </f.input>
+
+                  {{#if remainingEffortTracking}}
+                    <f.input @name="mostRecentRemainingEffort" as |fi|>
+                      <div class="form-group">
+                        <label>
+                          Remaing effort
+                        </label>
+                        <SyDurationpicker
+                          data-test-remaining-effort={{true}}
+                          @value={{fi.value}}
+                          @min={{0}}
+                          @onChange={{fi.update}}
+                        />
+                      </div>
+                    </f.input>
+                  {{/if}}
+
+                  <f.input @name="archived" as |fi|>
+                    <div class="form-group">
+                      <label>
+                        Archived
+                      </label>
+                      <SyCheckbox
+                        data-test-archived
+                        @checked={{this.selectedTask.archived}}
                         @value={{fi.value}}
                         @onChange={{fi.update}}
                       />
                     </div>
                   </f.input>
-                {{/if}}
-
-                <f.input @name="archived" as |fi|>
-                  <div class="form-group">
-                    <label>
-                      Archived
-                    </label>
-                    <SyCheckbox
-                      data-test-archived
-                      @checked={{this.selectedTask.archived}}
-                      @value={{fi.value}}
-                      @onChange={{fi.update}}
-                    />
-                  </div>
-                </f.input>
+                </div>
               </div>
-            </div>
-            <div class="btn-toolbar btn-toolbar--right">
-              <button
-                class="btn btn-primary"
-                data-test-cancel
-                type="button"
-                {{on "click" (fn (mut this.selectedTask) null)}}
-              >Cancel</button>
-              <f.submit data-test-save @disabled={{f.model.isInvalid}} />
-            </div>
-          </ValidatedForm>
-        </div>
-      {{/if}}
+              <div class="btn-toolbar btn-toolbar--right">
+                <button
+                  class="btn btn-primary"
+                  data-test-cancel
+                  type="button"
+                  {{on "click" (fn (mut this.selectedTask) null)}}
+                >Cancel</button>
+                <f.submit data-test-save @disabled={{f.model.isInvalid}} />
+              </div>
+            </ValidatedForm>
+          </div>
+        {{/if}}
+      {{/let}}
     {{else}}
       <div class="empty" data-test-none-selected>
         <div>

--- a/app/styles/projects.scss
+++ b/app/styles/projects.scss
@@ -94,29 +94,20 @@
 }
 
 .table--projects > colgroup > col {
-  &:nth-child(1),
-  &:nth-child(2),
-  &:nth-child(3) {
-    width: 8%;
+  &.title {
+    width: 10%;
   }
 
-  &:nth-child(4),
-  &:nth-child(5),
-  &:nth-child(6) {
-    width: 11%;
-  }
-
-  &:nth-child(8) {
-    width: 8%;
-  }
-
-  &:nth-child(9),
-  &:nth-child(10) {
-    width: 7%;
-  }
-
-  &:nth-child(7) {
+  &.reference {
     width: 20%;
+  }
+
+  &.duration {
+    width: 8%;
+  }
+
+  &.archived {
+    width: 5%;
   }
 }
 

--- a/tests/integration/components/progress-tooltip/component-test.js
+++ b/tests/integration/components/progress-tooltip/component-test.js
@@ -12,11 +12,9 @@ module("Integration | Component | progress tooltip", function (hooks) {
 
   hooks.beforeEach(function () {
     this.server.create("task");
-  });
 
-  test("renders", async function (assert) {
     this.set(
-      "model",
+      "project",
       EmberObject.create({
         id: 1,
         estimatedTime: moment.duration({ h: 50 }),
@@ -26,9 +24,24 @@ module("Integration | Component | progress tooltip", function (hooks) {
       })
     );
 
+    this.set(
+      "project_with_remaining_effort",
+      EmberObject.create({
+        id: 1,
+        estimatedTime: moment.duration({ h: 50 }),
+        constructor: EmberObject.create({
+          modelName: "project",
+        }),
+        totalRemainingEffort: moment.duration({ h: 2 }),
+        remainingEffortTracking: true,
+      })
+    );
+  });
+
+  test("renders", async function (assert) {
     await render(hbs`
       <span id='target'></span>
-      <ProgressTooltip @target='#target' @model={{this.model}} @visible={{true}} />
+      <ProgressTooltip @target='#target' @model={{this.project}} @visible={{true}} />
     `);
 
     assert.dom(".progress-tooltip").exists();
@@ -47,22 +60,9 @@ module("Integration | Component | progress tooltip", function (hooks) {
   });
 
   test("renders on project with remaining effort", async function (assert) {
-    this.set(
-      "model",
-      EmberObject.create({
-        id: 1,
-        estimatedTime: moment.duration({ h: 50 }),
-        constructor: EmberObject.create({
-          modelName: "project",
-        }),
-        totalRemainingEffort: moment.duration({ h: 2 }),
-        remainingEffortTracking: true,
-      })
-    );
-
     await render(hbs`
       <span id='target'></span>
-      <ProgressTooltip @target='#target' @model={{this.model}} @visible={{true}} />
+      <ProgressTooltip @target='#target' @model={{this.project_with_remaining_effort}} @visible={{true}} />
     `);
 
     assert
@@ -112,6 +112,7 @@ module("Integration | Component | progress tooltip", function (hooks) {
         constructor: EmberObject.create({
           modelName: "task",
         }),
+        project: this.project_with_remaining_effort,
       })
     );
 
@@ -154,16 +155,7 @@ module("Integration | Component | progress tooltip", function (hooks) {
   });
 
   test("uses danger color when the factor is more than 1", async function (assert) {
-    this.set(
-      "model",
-      EmberObject.create({
-        id: 1,
-        estimatedTime: moment.duration({ h: 100 }),
-        constructor: EmberObject.create({
-          modelName: "project",
-        }),
-      })
-    );
+    this.project.estimatedTime = moment.duration({ h: 100 });
 
     this.server.get("/projects/:id", function ({ projects }, request) {
       return {
@@ -176,24 +168,14 @@ module("Integration | Component | progress tooltip", function (hooks) {
 
     await render(hbs`
       <span id='target'></span>
-      <ProgressTooltip @target='#target' @model={{this.model}} @visible={{true}} />
+      <ProgressTooltip @target='#target' @model={{this.project}} @visible={{true}} />
     `);
 
     assert.dom(".progress-tooltip .badge--danger").exists();
-    // assert.dom(".progress-tooltip .progress-bar.danger").exists();
   });
 
   test("uses warning color when the factor is 0.9 or more", async function (assert) {
-    this.set(
-      "model",
-      EmberObject.create({
-        id: 1,
-        estimatedTime: moment.duration({ h: 100 }),
-        constructor: EmberObject.create({
-          modelName: "project",
-        }),
-      })
-    );
+    this.project.estimatedTime = moment.duration({ h: 100 });
 
     this.server.get("/projects/:id", function ({ projects }, request) {
       return {
@@ -206,10 +188,9 @@ module("Integration | Component | progress tooltip", function (hooks) {
 
     await render(hbs`
       <span id='target'></span>
-      <ProgressTooltip @target='#target' @model={{this.model}} @visible={{true}} />
+      <ProgressTooltip @target='#target' @model={{this.project}} @visible={{true}} />
     `);
 
     assert.dom(".progress-tooltip .badge--warning").exists();
-    // assert.dom(".progress-tooltip .progress-bar.warning").exists();
   });
 });


### PR DESCRIPTION
Adding or editing tasks on projects page will no longer yield side effects, namely changing the `remaining-effort` of the task even if it was not enabled on the project.

Further fixes: 
* won't show remaining effort in progress tooltips
* repairs the table layout for the tasks of the project
* changes behavior of the `sy-durationpicker` component to allow values equal to `max` or `min`. That allows to `00:00` fields like the remaining effort input.

Fixes #851 