### PR TITLE
fix(weekly-overview): refresh weekly overview graph

### DIFF
--- a/app/components/weekly-overview/template.hbs
+++ b/app/components/weekly-overview/template.hbs
@@ -1,5 +1,5 @@
 <div class="weekly-overview">
-  {{weekly-overview-benchmark showLabel=true  hours=20}}
+  {{weekly-overview-benchmark showLabel=true hours=20}}
   {{weekly-overview-benchmark showLabel=false hours=18}}
   {{weekly-overview-benchmark showLabel=false hours=16}}
   {{weekly-overview-benchmark showLabel=false hours=14}}
@@ -9,7 +9,7 @@
   {{weekly-overview-benchmark showLabel=false hours=6}}
   {{weekly-overview-benchmark showLabel=false hours=4}}
   {{weekly-overview-benchmark showLabel=false hours=2}}
-  {{weekly-overview-benchmark showLabel=true  hours=0}}
+  {{weekly-overview-benchmark showLabel=true hours=0}}
 
   {{weekly-overview-benchmark showLabel=true hours=this.hours expected=true}}
 

--- a/app/index/template.hbs
+++ b/app/index/template.hbs
@@ -9,7 +9,7 @@
     </div>
     <div class="grid-cell visible-md">
       <WeeklyOverview @expected={{this.expectedWorktime}}>
-        {{#each this.weeklyOverviewData as |d|}}
+        {{#each this.weeklyOverviewData.value as |d|}}
           <WeeklyOverviewDay
             @day={{d.day}}
             @active={{d.active}}


### PR DESCRIPTION
The formerly implemented tracked task did not properly refresh on store updates, so we switched to a tracked function.

Fixes #855 