### PR TITLE
ci: disable commitlint in ci

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,5 +1,8 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
+# skip in CI
+[ -n "$CI" ] && exit 0
+
 # lint commit message
 pnpm commitlint --edit $1


### PR DESCRIPTION
It blocks releases since the body line is certainly longer than 100 characters.