### PR TITLE
fix: all the `equal` warning moved to `strictEqual` with making sure …

### DIFF
--- a/tests/acceptance/analysis-test.js
+++ b/tests/acceptance/analysis-test.js
@@ -84,7 +84,7 @@ module("Acceptance | analysis", function (hooks) {
     await click(".filter-sidebar-reset");
 
     // ordering should not be resetted
-    assert.equal(currentURL(), "/analysis?ordering=-user__username%2Cid");
+    assert.strictEqual(currentURL(), "/analysis?ordering=-user__username%2Cid");
   });
 
   test("can have initial filters", async function (assert) {
@@ -124,11 +124,11 @@ module("Acceptance | analysis", function (hooks) {
     assert
       .dom("[data-test-filter-reviewer] .ember-power-select-selected-item")
       .exists();
-    assert.equal(
+    assert.strictEqual(
       find("[data-test-filter-billing-type] select").selectedIndex,
       1
     );
-    assert.equal(
+    assert.strictEqual(
       find("[data-test-filter-cost-center] select").selectedIndex,
       1
     );
@@ -136,19 +136,19 @@ module("Acceptance | analysis", function (hooks) {
     assert.dom("[data-test-filter-from-date] input").hasValue("01.12.2016");
     assert.dom("[data-test-filter-to-date] input").hasValue("01.12.2017");
 
-    assert.equal(
+    assert.strictEqual(
       findAll("[data-test-filter-review] button").indexOf(
         find("[data-test-filter-review] button.active")
       ),
       0
     );
-    assert.equal(
+    assert.strictEqual(
       findAll("[data-test-filter-not-billable] button").indexOf(
         find("[data-test-filter-not-billable] button.active")
       ),
       0
     );
-    assert.equal(
+    assert.strictEqual(
       findAll("[data-test-filter-verified] button").indexOf(
         find("[data-test-filter-verified] button.active")
       ),
@@ -181,7 +181,10 @@ module("Acceptance | analysis", function (hooks) {
 
     await click("[data-test-edit-all]");
 
-    assert.equal(currentURL(), "/analysis/edit?editable=1&ordering=-date%2Cid");
+    assert.strictEqual(
+      currentURL(),
+      "/analysis/edit?editable=1&ordering=-date%2Cid"
+    );
   });
 
   test("can edit selected reports", async function (assert) {

--- a/tests/acceptance/auth-test.js
+++ b/tests/acceptance/auth-test.js
@@ -26,7 +26,7 @@ module("Acceptance | auth", function (hooks) {
     await authenticateSession();
 
     await visit("/");
-    assert.equal(currentURL(), "/");
+    assert.strictEqual(currentURL(), "/");
   });
 
   skip("can logout", async function (assert) {

--- a/tests/acceptance/index-activities-edit-test.js
+++ b/tests/acceptance/index-activities-edit-test.js
@@ -33,7 +33,7 @@ module("Acceptance | index activities edit", function (hooks) {
 
     await click('[data-test-activity-row-id="1"]');
 
-    assert.equal(currentURL(), "/edit/1");
+    assert.strictEqual(currentURL(), "/edit/1");
 
     await waitFor(".customer-select");
     await taskSelect("[data-test-activity-edit-form]");
@@ -51,7 +51,7 @@ module("Acceptance | index activities edit", function (hooks) {
 
     await click("[data-test-activity-edit-form-save]");
 
-    assert.equal(currentURL(), "/");
+    assert.strictEqual(currentURL(), "/");
 
     assert.dom('[data-test-activity-row-id="1"]').includesText("Test");
   });
@@ -61,11 +61,11 @@ module("Acceptance | index activities edit", function (hooks) {
 
     await click('[data-test-activity-row-id="1"]');
 
-    assert.equal(currentURL(), "/edit/1");
+    assert.strictEqual(currentURL(), "/edit/1");
 
     await click("[data-test-activity-edit-form-delete]");
 
-    assert.equal(currentURL(), "/");
+    assert.strictEqual(currentURL(), "/");
 
     assert.dom('[data-test-activity-row-id="1"]').doesNotExist();
     assert.dom("[data-test-activity-row]").exists({ count: 4 });
@@ -89,15 +89,15 @@ module("Acceptance | index activities edit", function (hooks) {
 
     await click('[data-test-activity-row-id="1"]');
 
-    assert.equal(currentURL(), "/edit/1");
+    assert.strictEqual(currentURL(), "/edit/1");
 
     await click('[data-test-activity-row-id="2"]');
 
-    assert.equal(currentURL(), "/edit/2");
+    assert.strictEqual(currentURL(), "/edit/2");
 
     await click('[data-test-activity-row-id="2"]');
 
-    assert.equal(currentURL(), "/");
+    assert.strictEqual(currentURL(), "/");
   });
 
   test("validates time on blur", async function (assert) {
@@ -136,6 +136,6 @@ module("Acceptance | index activities edit", function (hooks) {
       transferred: true,
     });
     await visit(`/edit/${id}`);
-    assert.equal(currentURL(), "/");
+    assert.strictEqual(currentURL(), "/");
   });
 });

--- a/tests/acceptance/index-activities-test.js
+++ b/tests/acceptance/index-activities-test.js
@@ -26,7 +26,7 @@ module("Acceptance | index activities", function (hooks) {
   test("can visit /", async function (assert) {
     await visit("/");
 
-    assert.equal(currentURL(), "/");
+    assert.strictEqual(currentURL(), "/");
   });
 
   test("can list activities", async function (assert) {
@@ -59,7 +59,7 @@ module("Acceptance | index activities", function (hooks) {
       `[data-test-activity-row-id="${activity.id}"] [data-test-start-activity]`
     );
 
-    assert.equal(currentURL(), `/?day=${today.format("YYYY-MM-DD")}`);
+    assert.strictEqual(currentURL(), `/?day=${today.format("YYYY-MM-DD")}`);
 
     assert
       .dom(findAll('[data-test-activity-row-id="7"] td')[2])
@@ -90,7 +90,7 @@ module("Acceptance | index activities", function (hooks) {
 
     await click("[data-test-activity-generate-timesheet]");
 
-    assert.equal(currentURL(), "/reports");
+    assert.strictEqual(currentURL(), "/reports");
 
     assert.dom("[data-test-report-row]").exists({ count: 7 });
 
@@ -120,7 +120,7 @@ module("Acceptance | index activities", function (hooks) {
 
     await click("[data-test-activity-generate-timesheet]");
 
-    assert.equal(currentURL(), "/reports");
+    assert.strictEqual(currentURL(), "/reports");
 
     assert.dom("[data-test-report-row]").exists({ count: 6 });
 
@@ -128,7 +128,7 @@ module("Acceptance | index activities", function (hooks) {
 
     await click("[data-test-activity-generate-timesheet]");
 
-    assert.equal(currentURL(), "/reports");
+    assert.strictEqual(currentURL(), "/reports");
 
     assert.dom("[data-test-report-row]").exists({ count: 6 });
   });
@@ -141,12 +141,12 @@ module("Acceptance | index activities", function (hooks) {
     await click("[data-test-activity-generate-timesheet]");
     await click("[data-test-unknown-warning] button.btn-default");
 
-    assert.equal(currentURL(), "/");
+    assert.strictEqual(currentURL(), "/");
 
     await click("[data-test-activity-generate-timesheet]");
     await click("[data-test-unknown-warning] button.btn-primary");
 
-    assert.equal(currentURL(), "/reports");
+    assert.strictEqual(currentURL(), "/reports");
   });
 
   test("shows a warning when generating reports from day overlapping activities", async function (assert) {
@@ -325,7 +325,7 @@ module("Acceptance | index activities", function (hooks) {
 
     await click("[data-test-activity-generate-timesheet]");
 
-    assert.equal(currentURL(), "/reports");
+    assert.strictEqual(currentURL(), "/reports");
 
     assert.dom("[data-test-report-row]").exists({ count: 7 });
 

--- a/tests/acceptance/index-attendances-test.js
+++ b/tests/acceptance/index-attendances-test.js
@@ -24,7 +24,7 @@ module("Acceptance | index attendances", function (hooks) {
   test("can visit /attendances", async function (assert) {
     await visit("/attendances");
 
-    assert.equal(currentURL(), "/attendances");
+    assert.strictEqual(currentURL(), "/attendances");
   });
 
   test("can list attendances", async function (assert) {

--- a/tests/acceptance/index-reports-test.js
+++ b/tests/acceptance/index-reports-test.js
@@ -33,7 +33,7 @@ module("Acceptance | index reports", function (hooks) {
   test("can visit /reports", async function (assert) {
     await visit("/reports");
 
-    assert.equal(currentURL(), "/reports");
+    assert.strictEqual(currentURL(), "/reports");
   });
 
   test("can list reports", async function (assert) {
@@ -182,7 +182,7 @@ module("Acceptance | index reports", function (hooks) {
     await click(`button[data-date="${tomorrow}"]`);
     await click("[data-test-report-save]");
 
-    assert.equal(currentURL(), `/reports?day=${tomorrow}`);
+    assert.strictEqual(currentURL(), `/reports?day=${tomorrow}`);
     assert.dom("[data-test-report-row]").exists({ count: 6 });
   });
 });

--- a/tests/acceptance/index-test.js
+++ b/tests/acceptance/index-test.js
@@ -27,11 +27,11 @@ module("Acceptance | index", function (hooks) {
 
     const lastDay = moment().subtract(1, "day");
 
-    assert.equal(currentURL(), `/?day=${lastDay.format("YYYY-MM-DD")}`);
+    assert.strictEqual(currentURL(), `/?day=${lastDay.format("YYYY-MM-DD")}`);
 
     await click("[data-test-today]");
 
-    assert.equal(currentURL(), "/");
+    assert.strictEqual(currentURL(), "/");
   });
 
   test("can start a new activity", async function (assert) {

--- a/tests/acceptance/statistics-test.js
+++ b/tests/acceptance/statistics-test.js
@@ -153,7 +153,7 @@ module("Acceptance | statistics", function (hooks) {
       .dom("[data-test-filter-reviewer] .ember-power-select-selected-item")
       .exists();
 
-    assert.equal(
+    assert.strictEqual(
       find("[data-test-filter-billing-type] select").options.selectedIndex,
       1
     );

--- a/tests/acceptance/users-edit-credits-absence-credit-test.js
+++ b/tests/acceptance/users-edit-credits-absence-credit-test.js
@@ -26,7 +26,7 @@ module("Acceptance | users edit credits absence credit", function (hooks) {
     await fillIn("input[name=comment]", "Comment");
     await click("[data-test-absence-credit-save]");
 
-    assert.equal(currentURL(), `/users/${this.user.id}/credits`);
+    assert.strictEqual(currentURL(), `/users/${this.user.id}/credits`);
 
     assert.dom("[data-test-absence-credits] tbody > tr").exists({ count: 1 });
   });
@@ -38,7 +38,7 @@ module("Acceptance | users edit credits absence credit", function (hooks) {
 
     await click("[data-test-absence-credits] tbody > tr:first-child");
 
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       `/users/${this.user.id}/credits/absence-credits/${id}`
     );
@@ -49,7 +49,7 @@ module("Acceptance | users edit credits absence credit", function (hooks) {
 
     await click(".btn-primary");
 
-    assert.equal(currentURL(), `/users/${this.user.id}/credits`);
+    assert.strictEqual(currentURL(), `/users/${this.user.id}/credits`);
 
     assert.dom("[data-test-absence-credits] tbody > tr").exists({ count: 1 });
 
@@ -79,7 +79,7 @@ module("Acceptance | users edit credits absence credit", function (hooks) {
 
     await click(".btn-danger");
 
-    assert.equal(currentURL(), `/users/${this.user.id}/credits`);
+    assert.strictEqual(currentURL(), `/users/${this.user.id}/credits`);
 
     assert.dom("[data-test-absence-credits] tr").doesNotExist();
   });
@@ -97,7 +97,7 @@ module("Acceptance | users edit credits absence credit", function (hooks) {
 
     await click("[data-test-absence-credit-save]");
 
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       `/users/${this.user.id}/credits?year=${moment().year() + 1}`
     );

--- a/tests/acceptance/users-edit-credits-overtime-credit-test.js
+++ b/tests/acceptance/users-edit-credits-overtime-credit-test.js
@@ -25,7 +25,7 @@ module("Acceptance | users edit credits overtime credit", function (hooks) {
 
     await click("[data-test-overtime-credit-save]");
 
-    assert.equal(currentURL(), `/users/${this.user.id}/credits`);
+    assert.strictEqual(currentURL(), `/users/${this.user.id}/credits`);
 
     assert.dom("[data-test-overtime-credits] tbody > tr").exists({ count: 1 });
   });
@@ -37,7 +37,7 @@ module("Acceptance | users edit credits overtime credit", function (hooks) {
 
     await click("[data-test-overtime-credits] tbody > tr:first-child");
 
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       `/users/${this.user.id}/credits/overtime-credits/${id}`
     );
@@ -48,7 +48,7 @@ module("Acceptance | users edit credits overtime credit", function (hooks) {
 
     await click("[data-test-overtime-credit-save]");
 
-    assert.equal(currentURL(), `/users/${this.user.id}/credits`);
+    assert.strictEqual(currentURL(), `/users/${this.user.id}/credits`);
 
     assert.dom("[data-test-overtime-credits] tbody > tr").exists({ count: 1 });
 
@@ -78,7 +78,7 @@ module("Acceptance | users edit credits overtime credit", function (hooks) {
 
     await click("[data-test-overtime-credit-delete]");
 
-    assert.equal(currentURL(), `/users/${this.user.id}/credits`);
+    assert.strictEqual(currentURL(), `/users/${this.user.id}/credits`);
 
     assert.dom("[data-test-overtime-credits] tr").doesNotExist();
   });
@@ -95,7 +95,7 @@ module("Acceptance | users edit credits overtime credit", function (hooks) {
 
     await click("[data-test-overtime-credit-save]");
 
-    assert.equal(
+    assert.strictEqual(
       currentURL(),
       `/users/${this.user.id}/credits?year=${moment().year() + 1}`
     );

--- a/tests/acceptance/users-edit-credits-test.js
+++ b/tests/acceptance/users-edit-credits-test.js
@@ -51,6 +51,6 @@ module("Acceptance | users edit credits", function (hooks) {
 
     await click(".year-select .btn");
 
-    assert.equal(currentURL(), "/users/1/credits");
+    assert.strictEqual(currentURL(), "/users/1/credits");
   });
 });

--- a/tests/acceptance/users-test.js
+++ b/tests/acceptance/users-test.js
@@ -69,6 +69,6 @@ module("Acceptance | users", function (hooks) {
 
     await click(".filter-sidebar-reset");
 
-    assert.equal(currentURL(), "/users");
+    assert.strictEqual(currentURL(), "/users");
   });
 });

--- a/tests/integration/components/balance-donut/component-test.js
+++ b/tests/integration/components/balance-donut/component-test.js
@@ -18,7 +18,7 @@ module("Integration | Component | balance donut", function (hooks) {
     assert.dom(".donut-content").includesText("5 of 10");
     assert.dom(".donut-content").includesText("50%");
 
-    assert.equal(
+    assert.strictEqual(
       find(".donut-segment").getAttribute("stroke-dasharray"),
       "50 50"
     );
@@ -35,7 +35,7 @@ module("Integration | Component | balance donut", function (hooks) {
     assert.dom(".donut-content").includesText("3");
     assert.dom(".donut-content").doesNotIncludeText("0");
 
-    assert.equal(
+    assert.strictEqual(
       find(".donut-segment").getAttribute("stroke-dasharray"),
       "100 0"
     );
@@ -52,7 +52,7 @@ module("Integration | Component | balance donut", function (hooks) {
     assert.dom(".donut-content").includesText("20 of 10");
     assert.dom(".donut-content").includesText("200%");
 
-    assert.equal(
+    assert.strictEqual(
       find(".donut-segment").getAttribute("stroke-dasharray"),
       "100 0"
     );
@@ -67,7 +67,7 @@ module("Integration | Component | balance donut", function (hooks) {
 
     assert.dom(".donut-content").includesText("10:00");
 
-    assert.equal(
+    assert.strictEqual(
       find(".donut-segment").getAttribute("stroke-dasharray"),
       "100 0"
     );

--- a/tests/integration/components/date-buttons/component-test.js
+++ b/tests/integration/components/date-buttons/component-test.js
@@ -17,38 +17,44 @@ module("Integration | Component | date buttons", function (hooks) {
     );
 
     await click('[data-test-preset-date="0"]');
-    assert.equal(this.fromDate.format(format), moment().day(1).format(format));
+    assert.strictEqual(
+      this.fromDate.format(format),
+      moment().day(1).format(format)
+    );
     await click('[data-test-preset-date="1"]');
-    assert.equal(this.fromDate.format(format), moment().date(1).format(format));
+    assert.strictEqual(
+      this.fromDate.format(format),
+      moment().date(1).format(format)
+    );
     await click('[data-test-preset-date="2"]');
-    assert.equal(
+    assert.strictEqual(
       this.fromDate.format(format),
       moment().dayOfYear(1).format(format)
     );
     await click('[data-test-preset-date="3"]');
-    assert.equal(
+    assert.strictEqual(
       this.fromDate.format(format),
       moment().subtract(1, "week").day(1).format(format)
     );
-    assert.equal(
+    assert.strictEqual(
       this.toDate.format(format),
       moment().subtract(1, "week").day(7).format(format)
     );
     await click('[data-test-preset-date="4"]');
-    assert.equal(
+    assert.strictEqual(
       this.fromDate.format(format),
       moment().subtract(1, "month").startOf("month").format(format)
     );
-    assert.equal(
+    assert.strictEqual(
       this.toDate.format(format),
       moment().subtract(1, "month").endOf("month").format(format)
     );
     await click('[data-test-preset-date="5"]');
-    assert.equal(
+    assert.strictEqual(
       this.fromDate.format(format),
       moment().subtract(1, "year").startOf("year").format(format)
     );
-    assert.equal(
+    assert.strictEqual(
       this.toDate.format(format),
       moment().subtract(1, "year").endOf("year").format(format)
     );

--- a/tests/integration/components/date-navigation/component-test.js
+++ b/tests/integration/components/date-navigation/component-test.js
@@ -16,7 +16,7 @@ module("Integration | Component | date navigation", function (hooks) {
       hbs`<DateNavigation @current={{this.date}} @onChange={{fn (mut this.date)}} />`
     );
 
-    assert.equal(this.date.format("YYYY-MM-DD"), "2017-01-10");
+    assert.strictEqual(this.date.format("YYYY-MM-DD"), "2017-01-10");
   });
 
   test("can select the next day", async function (assert) {
@@ -28,7 +28,7 @@ module("Integration | Component | date navigation", function (hooks) {
 
     await click("[data-test-next]");
 
-    assert.equal(this.date.format("YYYY-MM-DD"), "2017-01-11");
+    assert.strictEqual(this.date.format("YYYY-MM-DD"), "2017-01-11");
   });
 
   test("can select the previous day", async function (assert) {
@@ -40,7 +40,7 @@ module("Integration | Component | date navigation", function (hooks) {
 
     await click("[data-test-previous]");
 
-    assert.equal(this.date.format("YYYY-MM-DD"), "2017-01-09");
+    assert.strictEqual(this.date.format("YYYY-MM-DD"), "2017-01-09");
   });
 
   test("can select the current day", async function (assert) {
@@ -52,6 +52,9 @@ module("Integration | Component | date navigation", function (hooks) {
 
     await click("[data-test-today]");
 
-    assert.equal(this.date.format("YYYY-MM-DD"), moment().format("YYYY-MM-DD"));
+    assert.strictEqual(
+      this.date.format("YYYY-MM-DD"),
+      moment().format("YYYY-MM-DD")
+    );
   });
 });

--- a/tests/integration/components/filter-sidebar/filter/component-test.js
+++ b/tests/integration/components/filter-sidebar/filter/component-test.js
@@ -18,7 +18,7 @@ module("Integration | Component | filter sidebar/filter", function (hooks) {
     });
 
     await render(hbs`
-      <FilterSidebar::Filter 
+      <FilterSidebar::Filter
         @type='button'
         @selected={{this.selected}}
         @options={{this.options}}
@@ -35,11 +35,11 @@ module("Integration | Component | filter sidebar/filter", function (hooks) {
       ["test 1", "test 2", "test 3"]
     );
 
-    assert.equal(find("button.active").innerHTML.trim(), "test 2");
+    assert.strictEqual(find("button.active").innerHTML.trim(), "test 2");
 
     await click("button:nth-child(1)");
 
-    assert.equal(this.selected, 1);
+    assert.strictEqual(this.selected, 1);
   });
 
   test("works with type select", async function (assert) {
@@ -53,7 +53,7 @@ module("Integration | Component | filter sidebar/filter", function (hooks) {
     });
 
     await render(hbs`
-      <FilterSidebar::Filter 
+      <FilterSidebar::Filter
         @type='select'
         @selected={{this.selected}}
         @options={{this.options}}
@@ -69,21 +69,21 @@ module("Integration | Component | filter sidebar/filter", function (hooks) {
       findAll("option").map((b) => b.innerHTML.trim()),
       ["test 1", "test 2", "test 3"]
     );
-    assert.equal(
+    assert.strictEqual(
       findAll("option")[find("select").options.selectedIndex].innerHTML.trim(),
       "test 2"
     );
 
     await fillIn("select", "1");
 
-    assert.equal(this.selected, "1");
+    assert.strictEqual(this.selected, "1");
   });
 
   test("works with type date", async function (assert) {
     this.set("selected", moment({ year: 2017, month: 10, day: 1 }));
 
     await render(hbs`
-      <FilterSidebar::Filter 
+      <FilterSidebar::Filter
         @type='date'
         @selected={{this.selected}}
         @onChange={{fn (mut this.selected)}}
@@ -94,7 +94,7 @@ module("Integration | Component | filter sidebar/filter", function (hooks) {
 
     await fillIn("input", "10.10.2010");
 
-    assert.equal(
+    assert.strictEqual(
       this.selected.format(),
       moment({ year: 2010, month: 9, day: 10 }).format()
     );
@@ -104,7 +104,7 @@ module("Integration | Component | filter sidebar/filter", function (hooks) {
     this.set("selected", "foobar");
 
     await render(hbs`
-      <FilterSidebar::Filter 
+      <FilterSidebar::Filter
         @type='search'
         @selected={{this.selected}}
         @onChange={{fn (mut this.selected)}}
@@ -115,7 +115,7 @@ module("Integration | Component | filter sidebar/filter", function (hooks) {
 
     await fillIn("input", "foobarbaz");
 
-    assert.equal(this.selected, "foobarbaz");
+    assert.strictEqual(this.selected, "foobarbaz");
   });
 
   test("works with block style", async function (assert) {

--- a/tests/integration/components/pagination-limit/component-test.js
+++ b/tests/integration/components/pagination-limit/component-test.js
@@ -21,6 +21,6 @@ module("Integration | Component | pagination limit", function (hooks) {
 
     await click("span:last-of-type a");
 
-    assert.equal(this.limit, 100);
+    assert.strictEqual(this.limit, 100);
   });
 });

--- a/tests/integration/components/progress-bar/component-test.js
+++ b/tests/integration/components/progress-bar/component-test.js
@@ -9,6 +9,6 @@ module("Integration | Component | progress bar", function (hooks) {
   test("renders", async function (assert) {
     await render(hbs`{{progress-bar 0.5}}`);
 
-    assert.equal(parseInt(find("progress").getAttribute("value")), 50);
+    assert.strictEqual(parseInt(find("progress").getAttribute("value")), 50);
   });
 });

--- a/tests/integration/components/sy-checkbox/component-test.js
+++ b/tests/integration/components/sy-checkbox/component-test.js
@@ -47,7 +47,7 @@ module("Integration | Component | sy checkbox", function (hooks) {
     );
 
     assert.ok(find("input").indeterminate);
-    assert.equal(this.checked, null);
+    assert.strictEqual(this.checked, null);
 
     await click("label");
 

--- a/tests/integration/components/sy-datepicker/component-test.js
+++ b/tests/integration/components/sy-datepicker/component-test.js
@@ -62,18 +62,18 @@ module("Integration | Component | sy datepicker", function (hooks) {
     find("input").value = "1.2.2018";
     await triggerEvent("input", "change");
 
-    assert.equal(this.value.format("YYYY-MM-DD"), "2018-02-01");
+    assert.strictEqual(this.value.format("YYYY-MM-DD"), "2018-02-01");
 
     find("input").value = "";
     await triggerEvent("input", "change");
 
-    assert.equal(this.value, null);
+    assert.strictEqual(this.value, null);
 
     find("input").value = "somewrongthing";
     await triggerEvent("input", "change");
 
     // value stays unchanged
-    assert.equal(this.value, null);
+    assert.strictEqual(this.value, null);
   });
 
   test("changes value on selection", async function (assert) {

--- a/tests/integration/components/sy-durationpicker/component-test.js
+++ b/tests/integration/components/sy-durationpicker/component-test.js
@@ -54,8 +54,8 @@ module("Integration | Component | sy durationpicker", function (hooks) {
     await fillIn("input", "13:15");
     await blur("input");
 
-    assert.equal(this.value.hours(), 13);
-    assert.equal(this.value.minutes(), 15);
+    assert.strictEqual(this.value.hours(), 13);
+    assert.strictEqual(this.value.minutes(), 15);
   });
 
   test("can set a negative value", async function (assert) {
@@ -74,7 +74,7 @@ module("Integration | Component | sy durationpicker", function (hooks) {
     await fillIn("input", "-13:00");
     await blur("input");
 
-    assert.equal(this.value.hours(), -13);
+    assert.strictEqual(this.value.hours(), -13);
   });
 
   test("can't set an invalid value", async function (assert) {
@@ -93,8 +93,8 @@ module("Integration | Component | sy durationpicker", function (hooks) {
     await fillIn("input", "abcdef");
     await blur("input");
 
-    assert.equal(this.value.hours(), 12);
-    assert.equal(this.value.minutes(), 30);
+    assert.strictEqual(this.value.hours(), 12);
+    assert.strictEqual(this.value.minutes(), 30);
   });
 
   test("can increase minutes per arrow", async function (assert) {
@@ -116,8 +116,8 @@ module("Integration | Component | sy durationpicker", function (hooks) {
 
     await settled();
 
-    assert.equal(this.value.hours(), 12);
-    assert.equal(this.value.minutes(), 30);
+    assert.strictEqual(this.value.hours(), 12);
+    assert.strictEqual(this.value.minutes(), 30);
   });
 
   test("can decrease minutes per arrow", async function (assert) {
@@ -139,8 +139,8 @@ module("Integration | Component | sy durationpicker", function (hooks) {
 
     await settled();
 
-    assert.equal(this.value.hours(), 12);
-    assert.equal(this.value.minutes(), 0);
+    assert.strictEqual(this.value.hours(), 12);
+    assert.strictEqual(this.value.minutes(), 0);
   });
 
   test("can't be bigger than max or smaller than min", async function (assert) {
@@ -178,8 +178,8 @@ module("Integration | Component | sy durationpicker", function (hooks) {
 
     await settled();
 
-    assert.equal(this.value.hours(), 12);
-    assert.equal(this.value.minutes(), 30);
+    assert.strictEqual(this.value.hours(), 12);
+    assert.strictEqual(this.value.minutes(), 30);
 
     this.element
       .querySelectorAll("input")
@@ -187,8 +187,8 @@ module("Integration | Component | sy durationpicker", function (hooks) {
 
     await settled();
 
-    assert.equal(this.value.hours(), 12);
-    assert.equal(this.value.minutes(), 30);
+    assert.strictEqual(this.value.hours(), 12);
+    assert.strictEqual(this.value.minutes(), 30);
   });
 
   test("can set a negative value with minutes", async function (assert) {
@@ -201,9 +201,9 @@ module("Integration | Component | sy durationpicker", function (hooks) {
     await fillIn("input", "-04:30");
     await blur("input");
 
-    assert.equal(this.value.hours(), -4);
-    assert.equal(this.value.minutes(), -30);
+    assert.strictEqual(this.value.hours(), -4);
+    assert.strictEqual(this.value.minutes(), -30);
 
-    assert.equal(formatDuration(this.value, false), "-04:30");
+    assert.strictEqual(formatDuration(this.value, false), "-04:30");
   });
 });

--- a/tests/integration/components/weekly-overview-benchmark/component-test.js
+++ b/tests/integration/components/weekly-overview-benchmark/component-test.js
@@ -15,7 +15,7 @@ module("Integration | Component | weekly overview benchmark", function (hooks) {
   test("computes the position correctly", async function (assert) {
     await render(hbs`{{weekly-overview-benchmark hours=10 max=10}}`);
 
-    assert.equal(
+    assert.strictEqual(
       find("hr").getAttribute("style"),
       "bottom: calc(100% / 10 * 10)"
     );
@@ -24,6 +24,6 @@ module("Integration | Component | weekly overview benchmark", function (hooks) {
   test("shows labels only when permitted", async function (assert) {
     await render(hbs`{{weekly-overview-benchmark showLabel=true hours=8.5}}`);
 
-    assert.equal(find("span").textContent, "8.5h");
+    assert.strictEqual(find("span").textContent, "8.5h");
   });
 });

--- a/tests/unit/components/worktime-balance-chart/component-test.js
+++ b/tests/unit/components/worktime-balance-chart/component-test.js
@@ -35,10 +35,10 @@ module("Unit | Component | worktime balance chart", function (hooks) {
     const titleFn = component.get("options.tooltips.callbacks.title");
     const labelFn = component.get("options.tooltips.callbacks.label");
 
-    assert.equal(
+    assert.strictEqual(
       titleFn([{ index: 0 }], { labels: [moment()] }),
       moment().format("DD.MM.YYYY")
     );
-    assert.equal(labelFn({ yLabel: 10.5 }), "10h 30m");
+    assert.strictEqual(labelFn({ yLabel: 10.5 }), "10h 30m");
   });
 });

--- a/tests/unit/helpers/balance-highlight-class-test.js
+++ b/tests/unit/helpers/balance-highlight-class-test.js
@@ -6,24 +6,24 @@ module("Unit | Helper | balance highlight class", function () {
   test("returns an empty string on neutral durations", function (assert) {
     const result = balanceHighlightClass([moment.duration({ h: 0, m: 0 })]);
 
-    assert.equal(result, "");
+    assert.strictEqual(result, "");
   });
 
   test("returns an empty string on anything other than a duration", function (assert) {
     const result = balanceHighlightClass([1337]);
 
-    assert.equal(result, "");
+    assert.strictEqual(result, "");
   });
 
   test("returns `color-success` on positive durations", function (assert) {
     const result = balanceHighlightClass([moment.duration({ h: 1, m: 30 })]);
 
-    assert.equal(result, "color-success");
+    assert.strictEqual(result, "color-success");
   });
 
   test("returns `color-danger` on negative durations", function (assert) {
     const result = balanceHighlightClass([moment.duration({ h: -1, m: 30 })]);
 
-    assert.equal(result, "color-danger");
+    assert.strictEqual(result, "color-danger");
   });
 });

--- a/tests/unit/helpers/format-duration-test.js
+++ b/tests/unit/helpers/format-duration-test.js
@@ -12,7 +12,7 @@ module("Unit | Helper | format duration", function () {
 
     const result = formatDurationFn([duration]);
 
-    assert.equal(result, "03:56:59");
+    assert.strictEqual(result, "03:56:59");
   });
 
   test("works without seconds", function (assert) {
@@ -24,6 +24,6 @@ module("Unit | Helper | format duration", function () {
 
     const result = formatDurationFn([duration, false]);
 
-    assert.equal(result, "03:56");
+    assert.strictEqual(result, "03:56");
   });
 });

--- a/tests/unit/helpers/humanize-duration-test.js
+++ b/tests/unit/helpers/humanize-duration-test.js
@@ -12,7 +12,7 @@ module("Unit | Helper | humanize duration", function () {
 
     const result = humanizeDurationFn([duration]);
 
-    assert.equal(result, "3h 56m");
+    assert.strictEqual(result, "3h 56m");
   });
 
   test("works with seconds", function (assert) {
@@ -24,6 +24,6 @@ module("Unit | Helper | humanize duration", function () {
 
     const result = humanizeDurationFn([duration, true]);
 
-    assert.equal(result, "3h 56m 59s");
+    assert.strictEqual(result, "3h 56m 59s");
   });
 });

--- a/tests/unit/helpers/parse-django-duration-test.js
+++ b/tests/unit/helpers/parse-django-duration-test.js
@@ -5,12 +5,12 @@ module("Unit | Helper | parse django duration", function () {
   test("works", function (assert) {
     const result = parseDjangoDurationFn(["11:30:00"]);
 
-    assert.equal(result.asHours(), 11.5);
+    assert.strictEqual(result.asHours(), 11.5);
   });
 
   test("works with a negative duration", function (assert) {
     const result = parseDjangoDurationFn(["-1 11:30:00"]);
 
-    assert.equal(result.asHours(), -12.5);
+    assert.strictEqual(result.asHours(), -12.5);
   });
 });

--- a/tests/unit/mixins/route-autostart-tour-test.js
+++ b/tests/unit/mixins/route-autostart-tour-test.js
@@ -19,11 +19,11 @@ module("Unit | Mixin | route autostart tour", function () {
       routeName: "foo.bar.baz",
     });
 
-    assert.equal(subject._getParentRouteName(), "foo.bar");
+    assert.strictEqual(subject._getParentRouteName(), "foo.bar");
 
     subject.set("routeName", "foo");
 
-    assert.equal(subject._getParentRouteName(), "");
+    assert.strictEqual(subject._getParentRouteName(), "");
   });
 
   test("can check if a tour is wanted", function (assert) {

--- a/tests/unit/models/attendance-test.js
+++ b/tests/unit/models/attendance-test.js
@@ -19,7 +19,7 @@ module("Unit | Model | attendance", function (hooks) {
         to: moment({ h: 17, m: 0, s: 0 }),
       });
 
-    assert.equal(model.get("duration").asHours(), 9);
+    assert.strictEqual(model.get("duration").asHours(), 9);
   });
 
   test("calculates the duration when the end time is 00:00", function (assert) {
@@ -30,6 +30,6 @@ module("Unit | Model | attendance", function (hooks) {
         to: moment({ h: 0, m: 0, s: 0 }),
       });
 
-    assert.equal(model.get("duration").asHours(), 24);
+    assert.strictEqual(model.get("duration").asHours(), 24);
   });
 });

--- a/tests/unit/models/user-test.js
+++ b/tests/unit/models/user-test.js
@@ -23,7 +23,7 @@ module("Unit | Model | user", function (hooks) {
 
     assert.ok(model);
 
-    assert.equal(model.get("fullName"), "Hans Muster");
+    assert.strictEqual(model.get("fullName"), "Hans Muster");
   });
 
   test("computes a long name with full name", function (assert) {
@@ -35,7 +35,7 @@ module("Unit | Model | user", function (hooks) {
 
     assert.ok(model);
 
-    assert.equal(model.get("longName"), "Hans Muster (hansm)");
+    assert.strictEqual(model.get("longName"), "Hans Muster (hansm)");
   });
 
   test("computes a long name without full name", function (assert) {
@@ -43,7 +43,7 @@ module("Unit | Model | user", function (hooks) {
 
     assert.ok(model);
 
-    assert.equal(model.get("longName"), "hansm");
+    assert.strictEqual(model.get("longName"), "hansm");
   });
 
   test("computes the active employment", function (assert) {
@@ -58,6 +58,6 @@ module("Unit | Model | user", function (hooks) {
       this.store.createRecord("employment", { id: 2, to: moment() }),
     ]);
 
-    assert.equal(Number(model.get("activeEmployment.id")), 1);
+    assert.strictEqual(Number(model.get("activeEmployment.id")), 1);
   });
 });

--- a/tests/unit/services/fetch-test.js
+++ b/tests/unit/services/fetch-test.js
@@ -15,7 +15,7 @@ module("Unit | Service | fetch", function (hooks) {
     const service = this.owner.lookup("service:fetch");
     const session = this.owner.lookup("service:session");
 
-    assert.equal(
+    assert.strictEqual(
       service.get("headers.authorization"),
       session.headers.authorization
     );

--- a/tests/unit/transforms/django-date-test.js
+++ b/tests/unit/transforms/django-date-test.js
@@ -16,7 +16,7 @@ module("Unit | Transform | django date", function (hooks) {
       })
     );
 
-    assert.equal(result, "2017-03-11");
+    assert.strictEqual(result, "2017-03-11");
   });
 
   test("deserializes", function (assert) {
@@ -27,8 +27,8 @@ module("Unit | Transform | django date", function (hooks) {
 
     const result = transform.deserialize("2017-03-11");
 
-    assert.equal(result.year(), 2017);
-    assert.equal(result.month(), 2); // moments months are zerobased
-    assert.equal(result.date(), 11);
+    assert.strictEqual(result.year(), 2017);
+    assert.strictEqual(result.month(), 2); // moments months are zerobased
+    assert.strictEqual(result.date(), 11);
   });
 });

--- a/tests/unit/transforms/django-datetime-test.js
+++ b/tests/unit/transforms/django-datetime-test.js
@@ -22,7 +22,7 @@ module("Unit | Transform | django datetime", function (hooks) {
 
     const result = transform.serialize(datetime);
 
-    assert.equal(result, datetime.format("YYYY-MM-DDTHH:mm:ss.SSSSZ"));
+    assert.strictEqual(result, datetime.format("YYYY-MM-DDTHH:mm:ss.SSSSZ"));
   });
 
   test("deserializes", function (assert) {
@@ -45,6 +45,6 @@ module("Unit | Transform | django datetime", function (hooks) {
       .deserialize(datetime.format("YYYY-MM-DDTHH:mm:ss.SSSSZ"))
       .utc();
 
-    assert.equal(result.toISOString(), datetime.toISOString());
+    assert.strictEqual(result.toISOString(), datetime.toISOString());
   });
 });

--- a/tests/unit/transforms/django-duration-test.js
+++ b/tests/unit/transforms/django-duration-test.js
@@ -10,7 +10,7 @@ module("Unit | Transform | django duration", function (hooks) {
 
     assert.notOk(transform.serialize(null));
 
-    assert.equal(
+    assert.strictEqual(
       transform.serialize(
         moment.duration({
           hours: 1,
@@ -21,7 +21,7 @@ module("Unit | Transform | django duration", function (hooks) {
       "01:02:03"
     );
 
-    assert.equal(
+    assert.strictEqual(
       transform.serialize(
         moment.duration({
           days: 1,
@@ -33,7 +33,7 @@ module("Unit | Transform | django duration", function (hooks) {
       "1 02:03:04"
     );
 
-    assert.equal(
+    assert.strictEqual(
       transform.serialize(
         moment.duration({
           hours: 1,
@@ -45,7 +45,7 @@ module("Unit | Transform | django duration", function (hooks) {
       "01:02:03.004000"
     );
 
-    assert.equal(
+    assert.strictEqual(
       transform.serialize(
         moment.duration({
           days: 1,
@@ -58,7 +58,7 @@ module("Unit | Transform | django duration", function (hooks) {
       "1 02:03:04.005000"
     );
 
-    assert.equal(
+    assert.strictEqual(
       transform.serialize(
         moment.duration({
           hours: -1,
@@ -69,7 +69,7 @@ module("Unit | Transform | django duration", function (hooks) {
       "-1 22:57:57"
     );
 
-    assert.equal(
+    assert.strictEqual(
       transform.serialize(
         moment.duration({
           days: -9,

--- a/tests/unit/transforms/django-time-test.js
+++ b/tests/unit/transforms/django-time-test.js
@@ -16,7 +16,7 @@ module("Unit | Transform | django time", function (hooks) {
       })
     );
 
-    assert.equal(result, "12:12:12");
+    assert.strictEqual(result, "12:12:12");
 
     const result2 = transform.serialize(
       moment({
@@ -26,7 +26,7 @@ module("Unit | Transform | django time", function (hooks) {
       })
     );
 
-    assert.equal(result2, "08:08:08");
+    assert.strictEqual(result2, "08:08:08");
   });
 
   test("deserializes", function (assert) {
@@ -34,14 +34,14 @@ module("Unit | Transform | django time", function (hooks) {
 
     const result = transform.deserialize("12:12:12");
 
-    assert.equal(result.hour(), 12);
-    assert.equal(result.minute(), 12);
-    assert.equal(result.second(), 12);
+    assert.strictEqual(result.hour(), 12);
+    assert.strictEqual(result.minute(), 12);
+    assert.strictEqual(result.second(), 12);
 
     const result2 = transform.deserialize("08:08:08");
 
-    assert.equal(result2.hour(), 8);
-    assert.equal(result2.minute(), 8);
-    assert.equal(result2.second(), 8);
+    assert.strictEqual(result2.hour(), 8);
+    assert.strictEqual(result2.minute(), 8);
+    assert.strictEqual(result2.second(), 8);
   });
 });

--- a/tests/unit/utils/format-duration-test.js
+++ b/tests/unit/utils/format-duration-test.js
@@ -12,7 +12,7 @@ module("Unit | Utility | format duration", function () {
 
     const result = formatDuration(duration);
 
-    assert.equal(result, "11:50:15");
+    assert.strictEqual(result, "11:50:15");
   });
 
   test("converts days into hours", function (assert) {
@@ -24,7 +24,7 @@ module("Unit | Utility | format duration", function () {
 
     const result = formatDuration(duration);
 
-    assert.equal(result, "44:24:19");
+    assert.strictEqual(result, "44:24:19");
   });
 
   test("zeropads all numbers", function (assert) {
@@ -36,7 +36,7 @@ module("Unit | Utility | format duration", function () {
 
     const result = formatDuration(duration);
 
-    assert.equal(result, "01:01:01");
+    assert.strictEqual(result, "01:01:01");
   });
 
   test("can hide seconds", function (assert) {
@@ -47,7 +47,7 @@ module("Unit | Utility | format duration", function () {
 
     const result = formatDuration(duration, false);
 
-    assert.equal(result, "22:12");
+    assert.strictEqual(result, "22:12");
   });
 
   test("can be negative", function (assert) {
@@ -59,17 +59,17 @@ module("Unit | Utility | format duration", function () {
 
     const result = formatDuration(duration);
 
-    assert.equal(result, "-01:01:01");
+    assert.strictEqual(result, "-01:01:01");
   });
 
   test("has a fallback", function (assert) {
     const result1 = formatDuration(null);
 
-    assert.equal(result1, "--:--:--");
+    assert.strictEqual(result1, "--:--:--");
 
     const result2 = formatDuration(null, false);
 
-    assert.equal(result2, "--:--");
+    assert.strictEqual(result2, "--:--");
   });
 
   test("works with a number instead of a duration", function (assert) {
@@ -77,10 +77,10 @@ module("Unit | Utility | format duration", function () {
 
     const result1 = formatDuration(num);
 
-    assert.equal(result1, "11:12:13");
+    assert.strictEqual(result1, "11:12:13");
 
     const result2 = formatDuration(num, false);
 
-    assert.equal(result2, "11:12");
+    assert.strictEqual(result2, "11:12");
   });
 });

--- a/tests/unit/utils/humanize-duration-test.js
+++ b/tests/unit/utils/humanize-duration-test.js
@@ -12,7 +12,7 @@ module("Unit | Utility | humanize duration", function () {
 
     const result = humanizeDuration(duration);
 
-    assert.equal(result, "11h 12m");
+    assert.strictEqual(result, "11h 12m");
   });
 
   test("works with seconds", function (assert) {
@@ -24,7 +24,7 @@ module("Unit | Utility | humanize duration", function () {
 
     const result = humanizeDuration(duration, true);
 
-    assert.equal(result, "11h 12m 13s");
+    assert.strictEqual(result, "11h 12m 13s");
   });
 
   test("renders days as hours", function (assert) {
@@ -36,19 +36,19 @@ module("Unit | Utility | humanize duration", function () {
 
     const result = humanizeDuration(duration);
 
-    assert.equal(result, "50h 0m");
+    assert.strictEqual(result, "50h 0m");
   });
 
   test("has a fallback", function (assert) {
     const result = humanizeDuration(null);
 
-    assert.equal(result, "0h 0m");
+    assert.strictEqual(result, "0h 0m");
   });
 
   test("has a fallback with seconds", function (assert) {
     const result = humanizeDuration(null, true);
 
-    assert.equal(result, "0h 0m 0s");
+    assert.strictEqual(result, "0h 0m 0s");
   });
 
   test("splits big numbers", function (assert) {
@@ -58,7 +58,7 @@ module("Unit | Utility | humanize duration", function () {
 
     const result = humanizeDuration(duration);
 
-    assert.equal(result, `${hours.toLocaleString("de-CH")}h 0m`);
+    assert.strictEqual(result, `${hours.toLocaleString("de-CH")}h 0m`);
   });
 
   test("works with negative durations", function (assert) {
@@ -66,6 +66,6 @@ module("Unit | Utility | humanize duration", function () {
       moment.duration({ hours: -4, minutes: -30 })
     );
 
-    assert.equal(result, "-4h 30m");
+    assert.strictEqual(result, "-4h 30m");
   });
 });

--- a/tests/unit/utils/parse-django-duration-test.js
+++ b/tests/unit/utils/parse-django-duration-test.js
@@ -7,7 +7,7 @@ module("Unit | Utility | parse django duration", function () {
     assert.notOk(parseDjangoDuration(""));
     assert.notOk(parseDjangoDuration(null));
 
-    assert.equal(
+    assert.strictEqual(
       parseDjangoDuration("01:02:03").asMilliseconds(),
       moment
         .duration({
@@ -18,7 +18,7 @@ module("Unit | Utility | parse django duration", function () {
         .asMilliseconds()
     );
 
-    assert.equal(
+    assert.strictEqual(
       parseDjangoDuration("1 02:03:04").asMilliseconds(),
       moment
         .duration({
@@ -30,7 +30,7 @@ module("Unit | Utility | parse django duration", function () {
         .asMilliseconds()
     );
 
-    assert.equal(
+    assert.strictEqual(
       parseDjangoDuration("01:02:03.004000").asMilliseconds(),
       moment
         .duration({
@@ -42,7 +42,7 @@ module("Unit | Utility | parse django duration", function () {
         .asMilliseconds()
     );
 
-    assert.equal(
+    assert.strictEqual(
       parseDjangoDuration("1 02:03:04.005000").asMilliseconds(),
       moment
         .duration({
@@ -55,7 +55,7 @@ module("Unit | Utility | parse django duration", function () {
         .asMilliseconds()
     );
 
-    assert.equal(
+    assert.strictEqual(
       parseDjangoDuration("-1 22:57:57").asMilliseconds(),
       moment
         .duration({
@@ -66,7 +66,7 @@ module("Unit | Utility | parse django duration", function () {
         .asMilliseconds()
     );
 
-    assert.equal(
+    assert.strictEqual(
       parseDjangoDuration("-10 22:57:57").asMilliseconds(),
       moment
         .duration({

--- a/tests/unit/utils/query-params-test.js
+++ b/tests/unit/utils/query-params-test.js
@@ -18,7 +18,7 @@ module("Unit | Utility | query params", function () {
 
     const result = serializeParachuteQueryParams(params, qp);
 
-    assert.equal(result.foo, 100);
+    assert.strictEqual(result.foo, 100);
   });
 
   test("can underline query params", function (assert) {

--- a/tests/unit/utils/url-test.js
+++ b/tests/unit/utils/url-test.js
@@ -29,6 +29,6 @@ module("Unit | Utility | url", function () {
 
     const result = toQueryString(params);
 
-    assert.equal(result, "foo=&bar=0&baz=test");
+    assert.strictEqual(result, "foo=&bar=0&baz=test");
   });
 });

--- a/tests/unit/validators/null-or-not-blank-test.js
+++ b/tests/unit/validators/null-or-not-blank-test.js
@@ -5,6 +5,6 @@ module("Unit | Validator | null or not blank", function () {
   test("works", function (assert) {
     assert.true(validateNullOrNotBlank()("key", "test"));
     assert.true(validateNullOrNotBlank()("key", null));
-    assert.equal(typeof validateNullOrNotBlank()("key", ""), "string");
+    assert.strictEqual(typeof validateNullOrNotBlank()("key", ""), "string");
   });
 });


### PR DESCRIPTION
…that all tests still running