### PR TITLE
fix: negative activities possible

### DIFF
--- a/app/index/attendances/controller.js
+++ b/app/index/attendances/controller.js
@@ -20,8 +20,19 @@ export default class AttendanceController extends Controller {
   @service store;
   @service tracking;
 
-  AttendacenValidator = AttendanceValidator;
+  AttendanceValidator = AttendanceValidator;
 
+  /**
+   * Validate the given changeset
+   *
+   * @method validateChangeset
+   * @param {EmberChangeset.Changeset} changeset The changeset to validate
+   * @public
+   */
+  @action
+  validateChangeset(changeset) {
+    changeset.validate();
+  }
   /**
    * All attendances currently in the store
    *

--- a/app/index/attendances/template.hbs
+++ b/app/index/attendances/template.hbs
@@ -27,16 +27,20 @@
                 data-test-attendance-slider
                 data-test-attendance-slider-id={{attendance.id}}
               >
-                <td>
+                <td class="form-group {{if model.error.from 'has-error'}}">
                   <SyTimepicker
                     @value={{model.from}}
                     @onChange={{fn (mut model.from)}}
+                    @max={{model.to}}
+                    @onFocusOut={{(fn this.validateChangeset model)}}
                   />
                 </td>
-                <td>
+                <td class="form-group {{if model.error.to 'has-error'}}">
                   <SyTimepicker
                     @value={{model.to}}
                     @onChange={{fn (mut model.to)}}
+                    @min={{model.from}}
+                    @onFocusOut={{(fn this.validateChangeset model)}}
                   />
                 </td>
                 <td>

--- a/app/validations/attendance.js
+++ b/app/validations/attendance.js
@@ -4,6 +4,7 @@
  * @public
  */
 import { validatePresence } from "ember-changeset-validations/validators";
+import validateMoment from "timed/validators/moment";
 
 /**
  * Validations for attendances
@@ -13,6 +14,6 @@ import { validatePresence } from "ember-changeset-validations/validators";
  */
 export default {
   date: validatePresence(true),
-  from: validatePresence(true),
-  to: validatePresence(true),
+  from: [validatePresence(true), validateMoment({ lt: "to" })],
+  to: [validatePresence(true), validateMoment({ gt: "from" })],
 };

--- a/app/validators/moment.js
+++ b/app/validators/moment.js
@@ -1,6 +1,13 @@
 import { get } from "@ember/object";
 import moment from "moment";
 
+function getDateTimeIfValid(momentObject) {
+  if (momentObject && momentObject._isValid) {
+    return momentObject;
+  }
+  return undefined;
+}
+
 /**
  * Validator to determine if a value is a valid moment object and if it is
  * greater or smaller than another property of the content.
@@ -24,7 +31,9 @@ export default function validateMoment(options = { gt: null, lt: null }) {
 
     if (options.gt) {
       const gtVal =
-        get(changes, options.gt) || get(content, options.gt) || moment();
+        getDateTimeIfValid(get(changes, options.gt)) ||
+        getDateTimeIfValid(get(content, options.gt)) ||
+        moment();
 
       if (newValue <= gtVal) {
         valid = false;
@@ -32,7 +41,9 @@ export default function validateMoment(options = { gt: null, lt: null }) {
     }
     if (options.lt) {
       const ltVal =
-        get(changes, options.lt) || get(content, options.lt) || moment();
+        getDateTimeIfValid(get(changes, options.lt)) ||
+        getDateTimeIfValid(get(content, options.lt)) ||
+        moment();
 
       if (newValue >= ltVal) {
         valid = false;

--- a/app/validators/moment.js
+++ b/app/validators/moment.js
@@ -26,7 +26,7 @@ export default function validateMoment(options = { gt: null, lt: null }) {
     }
     let valid = !!newValue && newValue._isValid;
     if (!valid) {
-      return "false";
+      return "The given value is not a valid value";
     }
 
     if (options.gt) {
@@ -35,7 +35,7 @@ export default function validateMoment(options = { gt: null, lt: null }) {
         getDateTimeIfValid(get(content, options.gt)) ||
         moment();
       if (newValue <= gtVal) {
-        valid = "false";
+        valid = `The value is smaller than ${options.gt}`;
       }
     }
     if (options.lt) {
@@ -45,7 +45,7 @@ export default function validateMoment(options = { gt: null, lt: null }) {
         moment();
 
       if (newValue >= ltVal) {
-        valid = "false";
+        valid = `The valus is larger than ${options.lt}`;
       }
     }
     return valid;

--- a/app/validators/moment.js
+++ b/app/validators/moment.js
@@ -34,9 +34,8 @@ export default function validateMoment(options = { gt: null, lt: null }) {
         getDateTimeIfValid(get(changes, options.gt)) ||
         getDateTimeIfValid(get(content, options.gt)) ||
         moment();
-
       if (newValue <= gtVal) {
-        valid = false;
+        valid = "false";
       }
     }
     if (options.lt) {
@@ -46,7 +45,7 @@ export default function validateMoment(options = { gt: null, lt: null }) {
         moment();
 
       if (newValue >= ltVal) {
-        valid = false;
+        valid = "false";
       }
     }
     return valid;

--- a/app/validators/moment.js
+++ b/app/validators/moment.js
@@ -26,7 +26,7 @@ export default function validateMoment(options = { gt: null, lt: null }) {
     }
     let valid = !!newValue && newValue._isValid;
     if (!valid) {
-      return valid;
+      return "false";
     }
 
     if (options.gt) {

--- a/tests/unit/validators/moment-test.js
+++ b/tests/unit/validators/moment-test.js
@@ -4,7 +4,7 @@ import validateMoment from "timed/validators/moment";
 
 module("Unit | Validator | moment", function () {
   test("works without value", function (assert) {
-    assert.false(validateMoment()("key", null, null, {}, {}));
+    assert.strictEqual(validateMoment()("key", null, null, {}, {}), "false");
     assert.true(validateMoment()("key", moment(), null, {}, {}));
   });
 
@@ -19,14 +19,15 @@ module("Unit | Validator | moment", function () {
       )
     );
 
-    assert.false(
+    assert.strictEqual(
       validateMoment({ gt: "otherKey" })(
         "key",
         moment(),
         null,
         {},
         { otherKey: moment().add(1, "second") }
-      )
+      ),
+      "false"
     );
   });
 
@@ -41,14 +42,15 @@ module("Unit | Validator | moment", function () {
       )
     );
 
-    assert.false(
+    assert.strictEqual(
       validateMoment({ lt: "otherKey" })(
         "key",
         moment(),
         null,
         {},
         { otherKey: moment().add(-1, "second") }
-      )
+      ),
+      "false"
     );
   });
 

--- a/tests/unit/validators/moment-test.js
+++ b/tests/unit/validators/moment-test.js
@@ -4,7 +4,10 @@ import validateMoment from "timed/validators/moment";
 
 module("Unit | Validator | moment", function () {
   test("works without value", function (assert) {
-    assert.strictEqual(validateMoment()("key", null, null, {}, {}), "false");
+    assert.strictEqual(
+      validateMoment()("key", null, null, {}, {}),
+      "The given value is not a valid value"
+    );
     assert.true(validateMoment()("key", moment(), null, {}, {}));
   });
 
@@ -27,7 +30,7 @@ module("Unit | Validator | moment", function () {
         {},
         { otherKey: moment().add(1, "second") }
       ),
-      "false"
+      "The value is smaller than otherKey"
     );
   });
 
@@ -50,7 +53,7 @@ module("Unit | Validator | moment", function () {
         {},
         { otherKey: moment().add(-1, "second") }
       ),
-      "false"
+      "The valus is larger than otherKey"
     );
   });
 


### PR DESCRIPTION
fix of #885 

the validation was checking the value in the changes, which was an empty object,
since an empty object was a valid value, (`undefined` and `null` are not acceptable), that's why the comparative was between moment instance and an empty object
