### PR TITLE
fix(task-selection): make selection more robust

### DIFF
--- a/app/index/activities/edit/controller.js
+++ b/app/index/activities/edit/controller.js
@@ -96,9 +96,9 @@ export default class IndexActivitiesEditController extends Controller {
   }
 
   @action
-  setTask(task) {
-    if (task.id !== this.changeset.task.id) {
-      this.changeset.task = task;
+  setTask(cs, task) {
+    if (task?.id !== cs.task?.id) {
+      cs.task = task;
     }
   }
 }

--- a/app/index/activities/edit/template.hbs
+++ b/app/index/activities/edit/template.hbs
@@ -12,7 +12,7 @@
       <TaskSelection
         @initial={{hash task=this.changeset.task}}
         @task={{this.changeset.task}}
-        @on-set-task={{fn this.setTask this.changeset.task}}
+        @on-set-task={{fn this.setTask this.changeset}}
         as |t|
       >
         <div class="form-group">{{t.customer}}</div>


### PR DESCRIPTION
Fixes #891 

* multiple selection of a recent task won't reset project & task
* initial selection will now resolve proxies to determine state (this decides whether to fetch all customers initially or not)