### PR TITLE
chore(dockerfile): pin pnpm to v7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM danlynn/ember-cli:3.28.5 as build
 
-RUN npm install -g pnpm
+# pin pnpm to v7 as long as we are on the ember-cli:3.28.5 image
+RUN npm install -g pnpm@7
 
 COPY package.json pnpm-lock.yaml /myapp/
 


### PR DESCRIPTION
As long as we depend on `danlynn/ember-cli:3.28.5` we are bound to `node v16.13.1`. But since v8 `pnpm` requires at least `node v16.14`. As temporary resolution we have to pin `pnpm` to v7.

This is [blocking the ghcr image job](https://github.com/adfinis/timed-frontend/actions/runs/4617203705/jobs/8163238354).