### PR TITLE
refactor(users): extract query param utils to generic controller

### DIFF
--- a/app/controllers/qpcontroller.js
+++ b/app/controllers/qpcontroller.js
@@ -1,0 +1,36 @@
+import Controller from "@ember/controller";
+import { next } from "@ember/runloop";
+
+export default class ControllersQPControllerController extends Controller {
+  #defaults = {};
+
+  constructor(...args) {
+    super(...args);
+
+    // defer until the extending controller has set it's query params
+    next(() => this.storeQPDefaults());
+  }
+
+  storeQPDefaults() {
+    this.queryParams.forEach((qp) => {
+      this.#defaults[qp] = this[qp];
+    });
+  }
+
+  resetQueryParams() {
+    this.queryParams.forEach((qp) => {
+      this[qp] = this.#defaults[qp];
+    });
+  }
+
+  get allQueryParams() {
+    return this.queryParams.reduce(
+      (acc, key) =>
+        Object.defineProperty(acc, key, {
+          value: this[key],
+          enumerable: true,
+        }),
+      {}
+    );
+  }
+}

--- a/app/users/index/controller.js
+++ b/app/users/index/controller.js
@@ -1,16 +1,18 @@
-import Controller from "@ember/controller";
 import { action, set } from "@ember/object";
 import { inject as service } from "@ember/service";
 import { tracked } from "@glimmer/tracking";
 import { restartableTask, timeout, hash } from "ember-concurrency";
 import { task as trackedTask } from "ember-resources/util/ember-concurrency";
 import moment from "moment";
+import QPController from "timed/controllers/qpcontroller";
 
-export default class UsersIndexController extends Controller {
+export default class UsersIndexController extends QPController {
   queryParams = ["search", "supervisor", "active", "ordering"];
+
   @service session;
   @service router;
   @service store;
+
   @tracked search = "";
   @tracked supervisor = null;
   @tracked active = "1";
@@ -18,6 +20,7 @@ export default class UsersIndexController extends Controller {
 
   constructor(...args) {
     super(...args);
+
     this.prefetchData.perform();
   }
 
@@ -38,22 +41,6 @@ export default class UsersIndexController extends Controller {
 
   get fetchData() {
     return this._fetchData ?? {};
-  }
-
-  get allQueryParams() {
-    return {
-      supervisor: this.supervisor,
-      search: this.search,
-      active: this.active,
-      ordering: this.ordering,
-    };
-  }
-
-  resetQueryParams() {
-    this.search = "";
-    this.supervisor = null;
-    this.active = "1";
-    this.ordering = "username";
   }
 
   @restartableTask

--- a/app/users/index/route.js
+++ b/app/users/index/route.js
@@ -1,22 +1,3 @@
 import Route from "@ember/routing/route";
 
-export default class UsersIndexRoute extends Route {
-  queryParams = {
-    search: {
-      refreshModel: true,
-      replace: true,
-    },
-    supervisor: {
-      refreshModel: true,
-      replace: true,
-    },
-    active: {
-      refreshModel: true,
-      replace: true,
-    },
-    ordering: {
-      refreshModel: true,
-      replace: true,
-    },
-  };
-}
+export default class UsersIndexRoute extends Route {}

--- a/tests/unit/controllers/qpcontroller/controller-test.js
+++ b/tests/unit/controllers/qpcontroller/controller-test.js
@@ -1,0 +1,12 @@
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+
+module("Unit | Controller | controllers/qpcontroller", function (hooks) {
+  setupTest(hooks);
+
+  // TODO: Replace this with your real tests.
+  test("it exists", function (assert) {
+    const controller = this.owner.lookup("controller:controllers/qpcontroller");
+    assert.ok(controller);
+  });
+});

--- a/tests/unit/controllers/qpcontroller/controller-test.js
+++ b/tests/unit/controllers/qpcontroller/controller-test.js
@@ -4,9 +4,25 @@ import { module, test } from "qunit";
 module("Unit | Controller | controllers/qpcontroller", function (hooks) {
   setupTest(hooks);
 
-  // TODO: Replace this with your real tests.
-  test("it exists", function (assert) {
-    const controller = this.owner.lookup("controller:controllers/qpcontroller");
-    assert.ok(controller);
+  test("get all query params", function (assert) {
+    const controller = this.owner.lookup("controller:qpcontroller");
+    controller.queryParams = ["qp1", "qp2"];
+    controller.qp1 = "baz";
+    controller.qp2 = "foo";
+
+    assert.strictEqual(controller.allQueryParams.qp1, "baz");
+    assert.strictEqual(controller.allQueryParams.qp2, "foo");
+  });
+
+  test("reset query params", function (assert) {
+    const controller = this.owner.lookup("controller:qpcontroller");
+    controller.queryParams = ["qp1", "qp2"];
+    controller.qp1 = "baz";
+    controller.qp2 = "foo";
+
+    controller.resetQueryParams();
+
+    assert.strictEqual(controller.allQueryParams.qp1, undefined);
+    assert.strictEqual(controller.allQueryParams.qp2, undefined);
   });
 });


### PR DESCRIPTION
As we want to move away from `ember-parachute` #723 , we have to handle query params by our own. Extracting those util methods to a generic controller is the first step to refactor all the other controllers currently depending on `ember-parachute` mixins.

Further this PR reverts a accidental change, where the QPs of the `users/index` controller where listed in the route query params hash separately.