### PR TITLE
fix(protected): await before model hook auth request

### DIFF
--- a/app/protected/route.js
+++ b/app/protected/route.js
@@ -24,8 +24,8 @@ export default class ProtectedRoute extends Route {
   @service store;
   @service fetch;
 
-  beforeModel(transition) {
-    this.session.requireAuthentication(transition, "login");
+  async beforeModel(transition) {
+    await this.session.requireAuthentication(transition, "login");
   }
 
   async model() {


### PR DESCRIPTION
We should await the `auth` response, before proceeding with further requests in the protected route. Otherwise it is more prune for race-conditions in the auth flow. Full description see: https://github.com/adfinis/ember-simple-auth-oidc/pull/761