### PR TITLE
chore(pnpm): add npmrc config file

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+# TODO: delete this when updating to pnpm v8
+auto-install-peers=false
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: '6.0'
 
 settings:
-  autoInstallPeers: true
+  autoInstallPeers: false
   excludeLinksFromLockfile: false
 
 overrides:


### PR DESCRIPTION
This helps keeping the settings for pnpm v7 and lockfile version v6 in line while also using dependabot for updates. Otherwise it would overwrite the 'autoInstallPeers' setting, as dependabot may use a different pnpm version. This specific setting is obsolete as soon as we update to pnpm v8.

See https://github.com/pnpm/pnpm/issues/6649 for more info.