### PR TITLE
fix: respect last value for remaining efforts for magic links

### DIFF
--- a/app/index/reports/route.js
+++ b/app/index/reports/route.js
@@ -27,8 +27,10 @@ export default class IndexReportsRoute extends Route {
 
     if (controller.task) {
       try {
+        const task = await this.store.findRecord("task", controller.task);
+
         await this.store.createRecord("report", {
-          task: await this.store.findRecord("task", controller.task),
+          task,
           duration: controller.duration
             ? moment.duration(controller.duration)
             : "",
@@ -37,6 +39,7 @@ export default class IndexReportsRoute extends Route {
           user: this.modelFor("protected"),
           review: controller.review ?? false,
           notBillable: controller.notBillable ?? false,
+          remainingEffort: task.mostRecentRemainingEffort,
         });
 
         controller.task = null;


### PR DESCRIPTION
Magic links now respect remaing effort estimates.

![image](https://github.com/adfinis/timed-frontend/assets/88476449/67ddda5c-2b3d-4298-8a92-b5883c302abd)

Resolves #1182