### PR TITLE
feat: highlight rows in analysis with the review flag

### DIFF
--- a/app/analysis/index/template.hbs
+++ b/app/analysis/index/template.hbs
@@ -350,9 +350,12 @@
                   {{#each reports as |report|}}
                     {{! template-lint-disable}}
                     <tr
-                      class="{{if
-                          (includes report.id this.selectedReportIds)
-                          'selected'
+                      class="{{concat
+                          (if
+                            (includes report.id this.selectedReportIds)
+                            'selected'
+                          )
+                          (if report.review ' needs-review')
                         }}
                         {{if
                           (or this.canBill (can 'edit report' report))

--- a/app/styles/analysis.scss
+++ b/app/styles/analysis.scss
@@ -54,6 +54,12 @@
 .table--analysis tr.selected {
   background-color: lighten($color-primary, 20%) !important;
 }
+.table--analysis tr.needs-review {
+  background-color: lighten($color-warning, 30%) !important;
+}
+.table--analysis tr.needs-review.selected {
+  background-color: #c4afed !important;
+}
 
 .table--analysis tr.selected + tr td,
 .table--analysis tr.selected td {


### PR DESCRIPTION
I routinely select a bunch of rows during review, click "edit selected reports" and then realise that i cant verify them because one of them had the review flag set and now i need to reselect them all. 

This is an attempt to alleviate this pain:

![image](https://github.com/adfinis/timed-frontend/assets/88476449/9f8ceb74-5e5d-45ee-9b33-12c11b416cc4)

A nicer solution would be to track the selection of the reports in the url, but that could potentially break a lot of business logic.
