### PR TITLE
fix(analysis): skip reset if edit is cancled

### DIFF
--- a/app/analysis/index/route.js
+++ b/app/analysis/index/route.js
@@ -14,8 +14,11 @@ export default class AnalysisIndexRoute extends Route {
   model() {
     /* eslint-disable-next-line ember/no-controller-access-in-routes */
     const controller = this.controllerFor("analysis.index");
+    const skipReset = controller.skipResetOnSetup;
     next(() => {
-      controller._reset();
+      if (!skipReset) {
+        controller._reset();
+      }
     });
   }
 

--- a/app/components/task-selection/component.js
+++ b/app/components/task-selection/component.js
@@ -97,6 +97,8 @@ export default class TaskSelectionComponent extends Component {
       task: null,
     };
 
+    const options = { preventAction: true };
+
     // the objects are possibily wrapped in a proxy which would
     // confuse the upcoming null check
     const [customer, project, task] = await Promise.all([
@@ -106,11 +108,11 @@ export default class TaskSelectionComponent extends Component {
     ]);
 
     if (task) {
-      this.onTaskChange(task);
+      this.onTaskChange(task, options);
     } else if (project) {
-      this.onProjectChange(project);
+      this.onProjectChange(project, options);
     } else if (customer) {
-      this.onCustomerChange(customer);
+      this.onCustomerChange(customer, options);
     } else {
       this.tracking.fetchCustomers.perform();
     }

--- a/tests/acceptance/analysis-test.js
+++ b/tests/acceptance/analysis-test.js
@@ -26,6 +26,10 @@ module("Acceptance | analysis", function (hooks) {
     await authenticateSession({ user_id: this.user.id });
 
     this.server.createList("report", 40, { userId: this.user.id });
+    this.reportIntersection = this.server.create("report-intersection", {
+      verified: false,
+      review: true,
+    });
   });
 
   test("can visit /analysis", async function (assert) {
@@ -166,6 +170,12 @@ module("Acceptance | analysis", function (hooks) {
     );
 
     await click("tbody > tr:first-child");
+
+    assert.ok(find("tbody > tr:first-child.selected"));
+
+    // check if selection remains after canceling the edit
+    await click("button[data-test-edit-selected]");
+    await click("button[data-test-cancel]");
 
     assert.ok(find("tbody > tr:first-child.selected"));
 


### PR DESCRIPTION
Restore the selection feature which was lost while refactoring.

https://github.com/adfinis/timed-frontend/blob/d0cb64e0b9f8bd37d5b92144127dc5b1b5dbac80/app/analysis/index/controller.js#L204C9-L204C38