### PR TITLE
fix: resetting `analysis.edit` query params

### DIFF
--- a/app/analysis/edit/route.js
+++ b/app/analysis/edit/route.js
@@ -10,7 +10,7 @@ export default class AnalysisEditRoute extends Route {
   }
   resetController(controller, isExiting, transition) {
     if (isExiting && transition.targetName !== "error") {
-      resetQueryParams(controller);
+      resetQueryParams(controller, controller.queryParams);
     }
   }
 }


### PR DESCRIPTION
fixes #1195